### PR TITLE
Add `bbop-registry` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3132,6 +3132,10 @@
       "resolved": "packages/bbop-graph",
       "link": true
     },
+    "node_modules/bbop-registry": {
+      "resolved": "packages/bbop-registry",
+      "link": true
+    },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
@@ -9168,6 +9172,20 @@
     },
     "packages/bbop-graph": {
       "version": "0.0.21",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bbop-core": "^0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "devDependencies": {
+        "chai": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=22 <25"
+      }
+    },
+    "packages/bbop-registry": {
+      "version": "0.0.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bbop-core": "^0.0.6",

--- a/packages/bbop-registry/README.md
+++ b/packages/bbop-registry/README.md
@@ -1,0 +1,11 @@
+# bbop-registry
+
+## Overview
+
+Generic lightweight listener/callback registry system.
+
+### Availability
+
+[GitHub](https://github.com/berkeleybop/bbop-js-monorepo/packages/bbop-registry)
+
+[NPM](https://www.npmjs.com/package/bbop-registry)

--- a/packages/bbop-registry/package.json
+++ b/packages/bbop-registry/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "bbop-registry",
+  "version": "0.0.3",
+  "description": "Generic lightweight listener/callback registry system.",
+  "keywords": [
+    "AmiGO",
+    "Berkeley BOP",
+    "GO",
+    "Gene Ontology",
+    "Minerva",
+    "Noctua",
+    "bbop",
+    "client",
+    "node",
+    "npm",
+    "server"
+  ],
+  "homepage": "https://berkeleybop.org/",
+  "bugs": {
+    "url": "https://github.com/berkeleybop/bbop-js-monorepo/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "SJC <sjcarbon@lbl.gov>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berkeleybop/bbop-js-monorepo.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/registry.mjs",
+      "require": "./dist/registry.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown --format esm --format cjs src/registry.js",
+    "prepack": "npm run build",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "bbop-core": "^0.0.6",
+    "underscore": "^1.13.8"
+  },
+  "devDependencies": {
+    "chai": "^6.2.2"
+  },
+  "engines": {
+    "node": ">=22 <25"
+  }
+}

--- a/packages/bbop-registry/src/registry.js
+++ b/packages/bbop-registry/src/registry.js
@@ -1,0 +1,169 @@
+/**
+ * Generic lightweight listener/callback registry system.
+ *
+ * @module bbop-registry
+ */
+
+import { default as us } from "underscore";
+import bbop from "bbop-core";
+
+var each = us.each;
+
+/**
+ * Contructor for BBOP registry. Takes a list of event categories as
+ * strings.
+ *
+ * @constructor
+ * @param {Array} evt_list - a list of strings that identify the events to be used
+ * @returns {Object} bbop registry object
+ */
+var registry = function (evt_list) {
+  this._is_a = "bbop-registry";
+
+  var registry_anchor = this;
+
+  // Handle the registration of call functions to get activated
+  // after certain events.
+  this.callback_registry = {};
+  each(evt_list, function (item) {
+    registry_anchor.callback_registry[item] = {};
+  });
+
+  /**
+   * Add the specified function from the registry, with an optional
+   * relative priority against other callback functions.
+   *
+   * The in_priority value is relative to others in the category,
+   * with a higher priority...getting priority.
+   *
+   * See also: <apply>
+   *
+   * @param {String} category - one of the pre-defined categories
+   * @param {Function} in_function - function
+   * @param {Number} [in_priority] - the higher the faster
+   * @param {String} [function_id] - a unique string to identify a function; generated if one is not given
+   * @returns {String} the ID for the registered function in the given category
+   */
+  this.register = function (category, in_function, in_priority, function_id) {
+    // Only these categories.
+    if (typeof registry_anchor.callback_registry[category] === "undefined") {
+      throw new Error("cannot register unknown category");
+    }
+
+    // The default priority is 0.
+    var priority = 0;
+    if (in_priority) {
+      priority = in_priority;
+    }
+
+    // The default ID is generated, but take one if given.
+    var fid = null;
+    if (function_id) {
+      fid = function_id;
+    } else {
+      fid = bbop.uuid();
+    }
+
+    // Final registration.
+    registry_anchor.callback_registry[category][fid] = {
+      runner: in_function,
+      priority: priority,
+    };
+
+    return fid;
+  };
+
+  /**
+   * Returns whether or not an id has already been registered to a
+   * category. Will return null if the category does not exist.
+   *
+   * @param {String} category - one of the pre-defined categories
+   * @param {String} function_id - a unique string to identify a function
+   * @returns {Boolean|null} true, false, or null
+   */
+  this.is_registered = function (category, function_id) {
+    var retval = null;
+
+    var anc = registry_anchor.callback_registry;
+
+    //
+    if (typeof anc[category] !== "undefined") {
+      retval = false;
+
+      if (typeof anc[category][function_id] !== "undefined") {
+        retval = true;
+      }
+    }
+
+    return retval;
+  };
+
+  /**
+   * Remove the specified function from the registry. Must specify a
+   * legitimate category and the function id of the function in it.
+   *
+   * @param {String} category - string
+   * @param {String} function_id - string
+   * @returns {Boolean} boolean on whether something was unregistered
+   */
+  this.unregister = function (category, function_id) {
+    var retval = false;
+    if (
+      registry_anchor.callback_registry[category] &&
+      registry_anchor.callback_registry[category][function_id]
+    ) {
+      delete registry_anchor.callback_registry[category][function_id];
+      retval = true;
+    }
+    return retval;
+  };
+
+  /**
+   * Generic getter for callback functions, returns by priority.
+   *
+   * @param {String} category - string
+   * @returns {Array} an ordered (by priority) list of function_id strings
+   */
+  this.get_callbacks = function (category) {
+    var cb_id_list = us.keys(registry_anchor.callback_registry[category]);
+    // Sort callback list according to priority.
+    var ptype_registry_anchor = this;
+    cb_id_list.sort(function (a, b) {
+      var pkg_a = ptype_registry_anchor.callback_registry[category][a];
+      var pkg_b = ptype_registry_anchor.callback_registry[category][b];
+      return pkg_b["priority"] - pkg_a["priority"];
+    });
+
+    // Collect the actual stored functions by priority.
+    var cb_fun_list = [];
+    for (var cbi = 0; cbi < cb_id_list.length; cbi++) {
+      var cb_id = cb_id_list[cbi];
+      var to_run = registry_anchor.callback_registry[category][cb_id]["runner"];
+      cb_fun_list.push(to_run);
+      // ll('callback: ' + category + ', ' + cb_id + ', ' +
+      //    this.callback_registry[category][cb_id]['priority']);
+    }
+
+    return cb_fun_list;
+  };
+
+  /**
+   * Generic runner for prioritized callbacks with various arguments
+   * and an optional change in context..
+   *
+   * @param {String} category - string
+   * @param {Array} arg_list - a list of arguments to pass to the function in the category
+   * @param {String} [context] - the context to apply the arguments in
+   */
+  this.apply_callbacks = function (category, arg_list, context) {
+    // Run all against registered functions.
+    var callbacks = registry_anchor.get_callbacks(category);
+    for (var ci = 0; ci < callbacks.length; ci++) {
+      var run_fun = callbacks[ci];
+      //run_fun(arg_list);
+      run_fun.apply(context, arg_list);
+    }
+  };
+};
+
+export default registry;

--- a/packages/bbop-registry/src/registry.js
+++ b/packages/bbop-registry/src/registry.js
@@ -10,7 +10,7 @@ import bbop from "bbop-core";
 var each = us.each;
 
 /**
- * Contructor for BBOP registry. Takes a list of event categories as
+ * Constructor for BBOP registry. Takes a list of event categories as
  * strings.
  *
  * @constructor

--- a/packages/bbop-registry/src/registry.test.js
+++ b/packages/bbop-registry/src/registry.test.js
@@ -1,0 +1,69 @@
+import { describe, it } from "node:test";
+import { assert } from "chai";
+import { default as us } from "underscore";
+
+import registry from "./registry.js";
+
+describe("overall functionality", function () {
+  it("basics", function () {
+    // Absolute basics.
+    var reg = new registry(["start", "stop", "reset"]);
+    assert.equal(us.keys(reg.callback_registry).length, 3, "3 categories");
+    assert.equal(us.keys(reg.callback_registry["reset"]).length, 0, "nothing in");
+
+    // Create testable environment.
+    var acc = 0;
+    function plus(plus_val) {
+      acc = acc + plus_val;
+    }
+    function mult(mult_val) {
+      acc = acc * mult_val;
+    }
+    function sum(val1, val2) {
+      acc = val1 + val2;
+    }
+
+    // Registration tests.
+    reg.register("reset", plus, 0, "0");
+    reg.register("reset", mult, 1, "1");
+    assert.equal(reg.get_callbacks("reset").length, 2, "2 callbacks");
+    reg.unregister("reset", "1");
+    assert.equal(reg.get_callbacks("reset").length, 1, "now 1 callback");
+
+    // Test apply.
+    acc = 0;
+    reg.register("start", plus, 0, "0");
+    reg.register("start", mult, 1, "1");
+    reg.apply_callbacks("start", [2]);
+    assert.equal(acc, 2, "higher priority goes first");
+
+    // Test apply and priority.
+    acc = 0;
+    reg.register("stop", plus, 1, "1");
+    reg.register("stop", mult, 0, "0");
+    reg.apply_callbacks("stop", [2]);
+    assert.equal(acc, 4, "apply test 2");
+
+    // Test multivalued apply.
+    acc = 0;
+    reg.unregister("stop", "0");
+    reg.unregister("stop", "1");
+    reg.register("stop", sum, -1, "-1");
+    reg.apply_callbacks("stop", [2, 3]);
+    assert.equal(acc, 5, "apply test 3");
+
+    // is_registered
+    assert.equal(null, reg.is_registered("foo", "bar"), "is_r? test 1");
+    assert.isFalse(reg.is_registered("stop", "bar"), "is_r? test 2");
+    assert.isTrue(reg.is_registered("stop", "-1"), "is_r? test 3");
+  });
+
+  it("implied ids work", function () {
+    var reg = new registry(["start", "stop", "reset"]);
+    var rid = reg.register("start", function () {});
+    assert.isTrue(reg.is_registered("start", rid), "can see dynamic id");
+
+    reg.unregister("start", rid);
+    assert.isFalse(reg.is_registered("start", rid), "delete by dynamic id");
+  });
+});


### PR DESCRIPTION
Fixes #5 

Adds the source code from the existing `bbop-registry` package into `packages/bbop-registry`. Note that the intention is _not_ to clean up that code. We're just consolidating into the monorepo while updating dependencies and Node.js compatibility. 