### PR TITLE
Add `bbop-client-barista` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2951,11 +2951,41 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+      "integrity": "sha512-AOPopplFOUlmUugwiZUCDpOwmqvSgdCyE8iJVLWI4NcB7qfMKQN34dn5xYtlUU03XGG5egRWW4NW5gIxpa5hEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.11",
+        "negotiator": "0.6.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha512-qTxkr1RoLw5Pz+1+PTJ/66hWuyi2LEOeOuIDJDlx6JF8x75bmD5C7qXTg2UlX5W9rLfkqKP+r8q6Vy6NWdWrbw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
       "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA==",
       "license": "MIT"
     },
     "node_modules/agent-base": {
@@ -3049,6 +3079,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/arraybuffer.slice": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+      "integrity": "sha512-6ZjfQaBSy6CuIH0+B0NrxMfDE5VIOCP/5gOqSpEIsaAZx9/giszzrXg6PZ7G51U/n88UmlAgYLNQ9wAnII7PJA=="
+    },
     "node_modules/arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -3096,12 +3131,26 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha512-437oANT9tP582zZMwSvZGy2nmSeAb8DW2me3y+Uv1Wp2Rulr8Mqlyrv3E7MLxmsiaPSMMDmiDVzgE+e8zlMx9g==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3124,6 +3173,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "integrity": "sha512-rz8L+d/xByiB/vLVftPkyY215fqNrmasrcJsYkVcm4TgJNz+YXKrFaFAWibSaHkiKoSgMDCb+lipOIRQNGYesw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/bbop-client-barista": {
+      "resolved": "packages/bbop-client-barista",
+      "link": true
+    },
     "node_modules/bbop-core": {
       "resolved": "packages/bbop-core",
       "link": true
@@ -3142,6 +3205,17 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha512-bYeph2DFlpK1XmGs6fvlLRUN29QISM3GBuUwSFsMY2XRx4AvC0WNCS57j4c/xGrK2RS24C1w3YoBOsw9fT46tQ==",
+      "dependencies": {
+        "callsite": "1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/bin-links": {
       "version": "5.0.0",
@@ -3228,6 +3302,11 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/blob": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "integrity": "sha512-YRc9zvVz4wNaxcXmiSgb9LAg7YYwqQ2xd0Sj6osfA7k/PKmIGVlnOYs3wOFdkRC9/JpQu8sGt/zHgJV7xzerfg=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -3365,6 +3444,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/callsites": {
@@ -3639,6 +3726,22 @@
         "dot-prop": "^5.1.0"
       }
     },
+    "node_modules/component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha512-WZveuKPeKAG9qY+FkYDeADzdHyTYdIboXS59ixDeRJL5ZhxpqUnxSOwop4FQjMsiYm3/Or8cegVbpAHNA7pHxw=="
+    },
+    "node_modules/component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA==",
+      "license": "MIT"
+    },
+    "node_modules/component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha512-w+LhYREhatpVqTESyGFg3NlP6Iu0kEKUHETY9GoZP/pQyW4mHFZuFWRUCIqVPZ36ueVLtoOEZaAqbCF2RDndaA=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3790,6 +3893,16 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/core-util-is": {
@@ -4156,6 +4269,87 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/engine.io": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.5.tgz",
+      "integrity": "sha512-j1DWIcktw4hRwrv6nWx++5nFH2X64x16MAG2P0Lmi5Dvdfi3I+Jhc7JKJIdAmDJa+5aZ/imHV7dWRPy2Cqjh3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "1.3.3",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "ws": "~1.1.5"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.6.tgz",
+      "integrity": "sha512-6+rInQu8xU7c0fIF6RC4SRKuHVWPt8Xq0bZYS4lMrTwmhRineOlEMsU3X0zS5mHIvCgJsmpOKEX7DhihGk7j0g==",
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "~1.1.5",
+        "xmlhttprequest-ssl": "1.6.3",
+        "yeast": "0.1.2"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "0.7.2"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ms": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "integrity": "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==",
+      "license": "MIT"
+    },
+    "node_modules/engine.io-parser": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+      "integrity": "sha512-3UyTJo+5Jbmr7rd3MosTAApK7BOIo4sjx8dJYSHa3Em5R3A9Y2s9GWu4JFJe6Px0VieJC0hKUA5NBytC+O7k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary": "0.1.7",
+        "wtf-8": "1.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "0.7.2"
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "integrity": "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
@@ -4888,6 +5082,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/has-binary": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+      "integrity": "sha512-k1Umb4/jrBWZbtL+QKSji8qWeoZ7ZTkXdnDXt1wxwBKAFM0//u96wDj43mBIqCIas8rDQMYyrBEvcS8hdGd4Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/has-binary/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
+    "node_modules/has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha512-g5VNKdkFuUuVCP9gYfDJHjK2nqdQJ7aDLTnycnc2+RvsOQbuLdF5pm7vuE5J76SEBIQjs4kQY/BWq74JUmjbXA==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5181,6 +5396,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -5577,6 +5797,12 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha512-I5YLeauH3rIaE99EE++UeH2M2gSYo8/2TqDac7oZEH6D/DSQ4Woa628Qrfj1X9/OY5Mk5VvIDQaKCDchXaKrmA==",
+      "deprecated": "Please use the native JSON object instead of JSON 3"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6870,6 +7096,21 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+      "integrity": "sha512-Lbc7GfN7XFaK30bzUN3cDYLOkT0dH05S0ax1QikylHUD9+Z9PRF3G1iYwX3kcz+6AlzTFGkUgMxz6l3aUwbwTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha512-S0sN3agnVh2SZNEIGc0N1X4Z5K0JeFbGBrnuZpsxuUh5XLF0BnvWkMjRXo/zGKLd/eghvNIKcx1pQkmUjXIyrA=="
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -6923,6 +7164,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha512-bOj3L1ypm++N+n7CEbbe473A414AB7z+amKYshRb//iuL3MpdDCLhPnw6aVTdKB9g5ZRVHIEp8eUln6L2NUStg==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ora": {
@@ -7426,6 +7675,33 @@
       "license": "MIT",
       "dependencies": {
         "parse-path": "^7.0.0"
+      }
+    },
+    "node_modules/parsejson": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+      "integrity": "sha512-v38ZjVbinlZ2r1Rz06WUZEnGoSRcEGX+roMsiWjHeAe23s2qlQUyfmsPQZvh7d8l0E8AZzTIO/RkUr00LfkSiA==",
+      "license": "MIT",
+      "dependencies": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "node_modules/parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha512-B3Nrjw2aL7aI4TDujOzfA4NsEc4u1lVcIRE0xesutH8kjeWF70uk+W5cBlIQx04zUH9NTBvuN36Y9xLRPK6Jjw==",
+      "license": "MIT",
+      "dependencies": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "node_modules/parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha512-ijhdxJu6l5Ru12jF0JvzXVPvsC+VibqeaExlNoMhWN6VQ79PGjkmc7oA4W1lp00sFkNyj0fx6ivPLdV51/UMog==",
+      "license": "MIT",
+      "dependencies": {
+        "better-assert": "~1.0.0"
       }
     },
     "node_modules/path-exists": {
@@ -8288,6 +8564,138 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/socket.io": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
+      "integrity": "sha512-rKMY/U7gBmbHjwrljcPHy+uEXZ5973WvO2DrooL643w1R24SZVzsmhvNmJFjYVhAL4y7wrZJJS/znUfp0VWfKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.3.3",
+        "engine.io": "~1.8.4",
+        "has-binary": "0.1.7",
+        "object-assign": "4.1.0",
+        "socket.io-adapter": "0.5.0",
+        "socket.io-client": "1.7.4",
+        "socket.io-parser": "2.3.1"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+      "integrity": "sha512-zmYvlFJay9skt4yk1MffE9p93HKvQtyy0BLZ5dRM73bOXFJXNZWq8qZVdY456sLaxdK6fHGiZ7glxzqvzwGzkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.3.3",
+        "socket.io-parser": "2.3.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "0.7.2"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "integrity": "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
+      "integrity": "sha512-vW9xr9XyTJejFS//7GNZmLTLkUSAcvOSxRXXhrojV+7wboTFB8CuvK1UBCW3NiB2kqyi0h9cTeyD7dXjdUd9jQ==",
+      "license": "MIT",
+      "dependencies": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "2.3.3",
+        "engine.io-client": "~1.8.4",
+        "has-binary": "0.1.7",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "2.3.1",
+        "to-array": "0.1.4"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "0.7.2"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/ms": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "integrity": "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "integrity": "sha512-j6l4g/+yWQjmy1yByzg1DPFL4vxQw+NwCJatIxni/AE1wfm17FBtIKSWU4Ay+onrJwDxmC4eK4QS/04ZsqYwZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "1.1.2",
+        "debug": "2.2.0",
+        "isarray": "0.0.1",
+        "json3": "3.3.2"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/component-emitter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+      "integrity": "sha512-YhIbp3PJiznERfjlIkK0ue4obZxt2S60+0W8z24ZymOHT8sHloOqWOqZRU2eN5OlY8U08VFsP02letcu26FilA=="
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "0.7.1"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "0.7.2"
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "integrity": "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/socks": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
@@ -8639,6 +9047,11 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha512-LhVdShQD/4Mk4zXNroIQZJC+Ap3zgLcDuwEdcmLv9CCO73NWockQDwyUnW/m8VX/EElfL6FcYx7EeutN4HJA6A=="
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -8857,6 +9270,12 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha512-QMpnpVtYaWEeY+MwKDN/UdKlE/LsFZXM5lO1u7GaZzNgmIbGixHEmVMIKT+vqYOALu3m5GYQy9kz4Xu4IVn7Ow==",
+      "license": "MIT"
+    },
     "node_modules/unconfig-core": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz",
@@ -9072,6 +9491,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/ws": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+      "license": "MIT",
+      "dependencies": {
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
+      }
+    },
+    "node_modules/wtf-8": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+      "integrity": "sha512-qfR6ovmRRMxNHgUNYI9LRdVofApe/eYrv4ggNOvvCP+pPdEo9Ym93QN4jUceGD6PignBbp2zAzgoE7GibAdq2A==",
+      "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -9144,6 +9587,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg==",
+      "license": "MIT"
+    },
     "node_modules/yoctocolors-cjs": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
@@ -9155,6 +9604,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/bbop-client-barista": {
+      "version": "0.0.7",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bbop-core": "^0.0.6",
+        "bbop-registry": "^0.0.3",
+        "socket.io-client": "^1.4.6",
+        "underscore": "^1.13.8"
+      },
+      "devDependencies": {
+        "chai": "^6.2.2",
+        "socket.io": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=22 <25"
       }
     },
     "packages/bbop-core": {

--- a/packages/bbop-client-barista/README.md
+++ b/packages/bbop-client-barista/README.md
@@ -1,0 +1,12 @@
+# bbop-client-barista
+
+## Overview
+
+Manager for handling per-model client-to-client and server-to-client
+communication via Barista.
+
+### Availability
+
+[GitHub](https://github.com/berkeleybop/bbop-js-monorepo/packages/bbop-client-barista)
+
+[NPM](https://www.npmjs.com/package/bbop-client-barista)

--- a/packages/bbop-client-barista/package.json
+++ b/packages/bbop-client-barista/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "bbop-client-barista",
+  "version": "0.0.7",
+  "description": "Manager for handling per-model client-to-client and server-to-client communication via Barista.",
+  "keywords": [
+    "Berkeley BOP",
+    "GO",
+    "Gene Ontology",
+    "Minerva",
+    "Noctua",
+    "bbop",
+    "berkeleybop",
+    "client",
+    "node",
+    "npm",
+    "server"
+  ],
+  "homepage": "https://berkeleybop.org/",
+  "bugs": {
+    "url": "https://github.com/berkeleybop/bbop-js-monorepo/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "SJC <sjcarbon@lbl.gov>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berkeleybop/bbop-js-monorepo.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/manager.mjs",
+      "require": "./dist/manager.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown --format esm --format cjs src/manager.js",
+    "prepack": "npm run build",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "bbop-core": "^0.0.6",
+    "bbop-registry": "^0.0.3",
+    "socket.io-client": "^1.4.6",
+    "underscore": "^1.13.8"
+  },
+  "devDependencies": {
+    "chai": "^6.2.2",
+    "socket.io": "^1.4.6"
+  },
+  "engines": {
+    "node": ">=22 <25"
+  }
+}

--- a/packages/bbop-client-barista/package.json
+++ b/packages/bbop-client-barista/package.json
@@ -43,8 +43,7 @@
   "dependencies": {
     "bbop-core": "^0.0.6",
     "bbop-registry": "^0.0.3",
-    "socket.io-client": "^1.4.6",
-    "underscore": "^1.13.8"
+    "socket.io-client": "^1.4.6"
   },
   "devDependencies": {
     "chai": "^6.2.2",

--- a/packages/bbop-client-barista/src/manager.js
+++ b/packages/bbop-client-barista/src/manager.js
@@ -1,0 +1,249 @@
+/*
+ * Manager for handling per-model client-to-client and
+ * server-to-client communication via Barista.
+ *
+ * Let's try and communicate with the socket.io server (Barista) for
+ * messages and the like--client-to-client communication.
+ *
+ * There are two major categories: "relay" and "query". Relays are for
+ * passing information on to other clients (e.g. "where I am");
+ * queries are for asking barista information about what it might know
+ * (e.g. "where is X").
+ *
+ * @module bbop-client-barista
+ */
+
+import bbop from "bbop-core";
+import registry from "bbop-registry";
+import io from "socket.io-client";
+
+/*
+ * Constructor: client
+ *
+ * Registry for client-to-client communication via Barista.
+ */
+function manager(barista_location, token) {
+  registry.call(this, [
+    "connect",
+    "initialization",
+    "relay",
+    "merge",
+    "rebuild",
+    "message",
+    "broadcast",
+    "clairvoyance",
+    "telekinesis",
+    "query",
+  ]);
+  this._is_a = "bbop-client-barista";
+
+  var anchor = this;
+  anchor._token = token;
+  anchor.socket = null;
+  anchor.model_id = null;
+  anchor.okay_p = null;
+
+  var known_relay_classes = {
+    relay: true,
+    message: true,
+    broadcast: true,
+    merge: true,
+    rebuild: true,
+    clairvoyance: true,
+    telekinesis: true,
+  };
+  var known_query_classes = {
+    query: true,
+  };
+
+  var logger = new bbop.logger("barista client");
+  logger.DEBUG = true;
+
+  function ll(str) {
+    if (logger.DEBUG === true) {
+      logger.kvetch(str);
+    }
+  }
+
+  if (typeof io === "undefined" || typeof io.connect === "undefined") {
+    ll("was unable to load server.io from messaging server (io undefined)");
+    anchor.okay_p = false;
+  } else {
+    ll("likely have the right setup--attempting");
+    anchor.okay_p = true;
+  }
+
+  anchor.logger = function (bool) {
+    if (typeof bool === "boolean") {
+      logger.DEBUG = bool;
+    }
+
+    return logger.DEBUG;
+  };
+
+  anchor.okay = function () {
+    var ret = false;
+    if (anchor.okay_p) {
+      ret = true;
+    }
+    return ret;
+  };
+
+  anchor.token = function (in_token) {
+    if (in_token) {
+      anchor._token = in_token;
+    }
+    return anchor._token;
+  };
+
+  anchor.relay = function (relay_class, data) {
+    if (!anchor.okay()) {
+      ll("no good socket on location; did you connect()?");
+    } else {
+      data.class = relay_class;
+      data.model_id = anchor.model_id;
+      data.token = anchor.token();
+
+      anchor.socket.emit("relay", data);
+    }
+  };
+
+  anchor.query = function (query_class, data) {
+    if (!anchor.okay()) {
+      ll("no good socket on location; did you connect()?");
+    } else {
+      ll("sending query: (" + anchor.model_id + ", " + anchor.token() + ")");
+
+      data.class = query_class;
+      data.model_id = anchor.model_id;
+      data.token = anchor.token();
+
+      anchor.socket.emit("query", data);
+    }
+  };
+
+  anchor.get_layout = function () {
+    anchor.query("query", { query: "layout" });
+  };
+
+  anchor.connect = function (model_id) {
+    if (!anchor.okay()) {
+      ll("no good socket on connect; did you connect()?");
+    } else {
+      anchor.socket = io.connect(barista_location);
+      anchor.model_id = model_id;
+      anchor.socket_id = anchor.socket.id;
+
+      var _inject_data_with_client_info = function (data) {
+        if (!data) {
+          data = {};
+        }
+
+        return data;
+      };
+
+      var _applies_to_us_p = function (data) {
+        var ret = false;
+
+        var mid = data.model_id || null;
+        if (!mid || mid !== anchor.model_id) {
+          ll("skip packet--not for us");
+        } else {
+          ret = true;
+        }
+
+        return ret;
+      };
+
+      anchor.socket.on("connect", function (empty_placeholder) {
+        var data = _inject_data_with_client_info(empty_placeholder);
+
+        data.message_type = "success";
+        data.message = "new client connected";
+        anchor.relay("message", data);
+
+        ll('apply "connect" callbacks');
+        anchor.apply_callbacks("connect", [data]);
+      });
+
+      anchor.socket.on("initialization", function (data) {
+        data = _inject_data_with_client_info(data);
+
+        ll('apply "initialization" callbacks');
+        anchor.apply_callbacks("initialization", [data]);
+      });
+
+      anchor.socket.on("relay", function (data) {
+        data = _inject_data_with_client_info(data);
+
+        var dclass = data.class;
+        if (!dclass) {
+          ll("no relay class found");
+        } else if (!known_relay_classes[dclass]) {
+          ll("unknown relay class: " + dclass);
+        } else {
+          if (dclass === "broadcast") {
+            ll('apply (relay/bcast) "' + dclass + '" callbacks');
+            anchor.apply_callbacks(dclass, [data]);
+          } else if (_applies_to_us_p(data)) {
+            ll('apply (relay) "' + dclass + '" callbacks');
+            anchor.apply_callbacks(dclass, [data]);
+          }
+        }
+      });
+
+      anchor.socket.on("query", function (data) {
+        data = _inject_data_with_client_info(data);
+
+        if (_applies_to_us_p(data)) {
+          var dclass = data.class;
+          if (!dclass) {
+            ll("no query class found");
+          } else if (!known_query_classes[dclass]) {
+            ll("unknown query class: " + dclass);
+          } else {
+            ll('apply (query) "' + dclass + '" callbacks');
+            anchor.apply_callbacks(dclass, [data]);
+          }
+        }
+      });
+    }
+  };
+
+  anchor.message = function (m) {
+    m.class = "message";
+    anchor.relay("message", m);
+  };
+
+  anchor.broadcast = function (m) {
+    m.class = "broadcast";
+    anchor.relay("broadcast", m);
+  };
+
+  anchor.clairvoyance = function (top, left) {
+    var packet = {
+      class: "clairvoyance",
+      top: top,
+      left: left,
+    };
+    anchor.relay("clairvoyance", packet);
+  };
+
+  anchor.telekinesis = function (item_id, top, left) {
+    var packet = {
+      class: "telekinesis",
+      objects: [
+        {
+          item_id: item_id,
+          top: top,
+          left: left,
+        },
+      ],
+    };
+    anchor.relay("telekinesis", packet);
+  };
+}
+
+bbop.extend(manager, registry);
+
+export default manager;

--- a/packages/bbop-client-barista/src/manager.test.js
+++ b/packages/bbop-client-barista/src/manager.test.js
@@ -1,0 +1,153 @@
+import { after, before, describe, it } from "node:test";
+import { assert } from "chai";
+import http from "node:http";
+
+import manager from "./manager.js";
+import socketIo from "socket.io";
+
+function waitForEvent(client, category, predicate) {
+  return new Promise(function (resolve) {
+    client.register(category, function (data) {
+      if (!predicate || predicate(data)) {
+        resolve(data);
+      }
+    });
+  });
+}
+
+async function closeClient(client) {
+  if (!client || !client.socket) {
+    return;
+  }
+
+  await new Promise(function (resolve) {
+    client.socket.once("disconnect", function () {
+      resolve();
+    });
+    client.socket.close();
+  });
+}
+
+describe("barista client can function minimally", function () {
+  var server = null;
+  var io = null;
+  var baseUrl = null;
+
+  before(async function () {
+    server = http.createServer();
+    io = socketIo(server);
+
+    io.on("connection", function (socket) {
+      socket.emit("initialization", {
+        class: "initialization",
+        model_id: "gomodel:test",
+        message: "ready",
+      });
+
+      socket.on("relay", function (data) {
+        socket.emit("relay", data);
+      });
+
+      socket.on("query", function (data) {
+        socket.emit("query", data);
+      });
+    });
+
+    await new Promise(function (resolve) {
+      server.listen(0, "127.0.0.1", function () {
+        var address = server.address();
+        baseUrl = "http://127.0.0.1:" + address.port;
+        resolve();
+      });
+    });
+  });
+
+  after(async function () {
+    await new Promise(function (resolve, reject) {
+      io.close();
+
+      if (!server.listening) {
+        resolve();
+        return;
+      }
+
+      server.close(function (error) {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+
+  it("connects and receives initialization", async function () {
+    var client = new manager(baseUrl, "test-token");
+    client.logger(false);
+
+    var connectPromise = waitForEvent(client, "connect");
+    var initPromise = waitForEvent(client, "initialization");
+
+    client.connect("gomodel:test");
+
+    var connectData = await connectPromise;
+    var initData = await initPromise;
+
+    assert.isTrue(client.okay());
+    assert.equal(connectData.model_id, "gomodel:test");
+    assert.equal(connectData.token, "test-token");
+    assert.equal(connectData.message_type, "success");
+    assert.equal(initData.message, "ready");
+
+    await closeClient(client);
+  });
+
+  it("relays messages scoped to the current model", async function () {
+    var client = new manager(baseUrl, "relay-token");
+    client.logger(false);
+
+    var relayPromise = waitForEvent(client, "message", function (data) {
+      return data.message === "hello world";
+    });
+    var connectPromise = waitForEvent(client, "connect");
+
+    client.connect("gomodel:test");
+    await connectPromise;
+
+    client.message({
+      message_type: "info",
+      message: "hello world",
+    });
+
+    var relayData = await relayPromise;
+
+    assert.equal(relayData.class, "message");
+    assert.equal(relayData.message, "hello world");
+    assert.equal(relayData.model_id, "gomodel:test");
+    assert.equal(relayData.token, "relay-token");
+
+    await closeClient(client);
+  });
+
+  it("queries and receives responses for the current model", async function () {
+    var client = new manager(baseUrl, "query-token");
+    client.logger(false);
+
+    var queryPromise = waitForEvent(client, "query");
+    var connectPromise = waitForEvent(client, "connect");
+
+    client.connect("gomodel:test");
+    await connectPromise;
+
+    client.get_layout();
+
+    var queryData = await queryPromise;
+
+    assert.equal(queryData.class, "query");
+    assert.equal(queryData.query, "layout");
+    assert.equal(queryData.model_id, "gomodel:test");
+    assert.equal(queryData.token, "query-token");
+
+    await closeClient(client);
+  });
+});


### PR DESCRIPTION
Fixes #6 

These changes bring in the source code of `bbop-client-barista` with standard tooling and code changes. The existing test was essentially a no-op. These changes add `socket.io` (the server package) as a dev dependency and spin up a local server for basic unit tests.