### PR TITLE
Add `bbop-graph-noctua` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3195,6 +3195,10 @@
       "resolved": "packages/bbop-graph",
       "link": true
     },
+    "node_modules/bbop-graph-noctua": {
+      "resolved": "packages/bbop-graph-noctua",
+      "link": true
+    },
     "node_modules/bbop-layout": {
       "resolved": "packages/bbop-layout",
       "link": true
@@ -3555,6 +3559,39 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/class-expression": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/class-expression/-/class-expression-0.0.13.tgz",
+      "integrity": "sha512-EmaEYPe8BulR3G6ztoAweIfst3huUGa+MXHqHBATjpn/Xe27qM0znOWPGzVBjua8geyf8n2wl+3y7lO426Pn9A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bbop-core": "0.0.5",
+        "underscore": "1.8.3"
+      },
+      "engines": {
+        "node": ">= 0.12.2",
+        "npm": ">= 2.7.4"
+      }
+    },
+    "node_modules/class-expression/node_modules/bbop-core": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/bbop-core/-/bbop-core-0.0.5.tgz",
+      "integrity": "sha512-pXL+19Cz7W+pOGUnOlG4iGnWButiRgjXw3aWC5jupC8l1LpxrXf8v6Hb0CzdQFh2+miaucuHHUm2IZ6qW9d0zg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "underscore": "1.8.3"
+      },
+      "engines": {
+        "node": ">= 0.12.2",
+        "npm": ">= 2.7.4"
+      }
+    },
+    "node_modules/class-expression/node_modules/underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==",
+      "license": "MIT"
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -9653,6 +9690,22 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "bbop-core": "^0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "devDependencies": {
+        "chai": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=22 <25"
+      }
+    },
+    "packages/bbop-graph-noctua": {
+      "version": "0.0.35",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bbop-core": "^0.0.6",
+        "bbop-graph": "^0.0.21",
+        "class-expression": "^0.0.13",
         "underscore": "^1.13.8"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3561,37 +3561,8 @@
       }
     },
     "node_modules/class-expression": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/class-expression/-/class-expression-0.0.13.tgz",
-      "integrity": "sha512-EmaEYPe8BulR3G6ztoAweIfst3huUGa+MXHqHBATjpn/Xe27qM0znOWPGzVBjua8geyf8n2wl+3y7lO426Pn9A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "bbop-core": "0.0.5",
-        "underscore": "1.8.3"
-      },
-      "engines": {
-        "node": ">= 0.12.2",
-        "npm": ">= 2.7.4"
-      }
-    },
-    "node_modules/class-expression/node_modules/bbop-core": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/bbop-core/-/bbop-core-0.0.5.tgz",
-      "integrity": "sha512-pXL+19Cz7W+pOGUnOlG4iGnWButiRgjXw3aWC5jupC8l1LpxrXf8v6Hb0CzdQFh2+miaucuHHUm2IZ6qW9d0zg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "underscore": "1.8.3"
-      },
-      "engines": {
-        "node": ">= 0.12.2",
-        "npm": ">= 2.7.4"
-      }
-    },
-    "node_modules/class-expression/node_modules/underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==",
-      "license": "MIT"
+      "resolved": "packages/class-expression",
+      "link": true
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -9733,6 +9704,20 @@
     },
     "packages/bbop-registry": {
       "version": "0.0.3",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bbop-core": "^0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "devDependencies": {
+        "chai": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=22 <25"
+      }
+    },
+    "packages/class-expression": {
+      "version": "0.0.13",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bbop-core": "^0.0.6",

--- a/packages/bbop-graph-noctua/README.md
+++ b/packages/bbop-graph-noctua/README.md
@@ -1,0 +1,13 @@
+# bbop-graph-noctua
+
+## Overview
+
+A Noctua-specific subclass of the bbop-graph general graph library.
+The purpose is to add named edges, evidence, types, and other features
+found in a Noctua environment.
+
+### Availability
+
+[GitHub](https://github.com/berkeleybop/bbop-js-monorepo/packages/bbop-graph-noctua)
+
+[NPM](https://www.npmjs.com/package/bbop-graph-noctua)

--- a/packages/bbop-graph-noctua/package.json
+++ b/packages/bbop-graph-noctua/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "bbop-graph-noctua",
+  "version": "0.0.35",
+  "description": "A subclass of bbop-graph that layers on a complete annotation and graph editing model for the Noctua set of tools.",
+  "keywords": [
+    "Berkeley BOP",
+    "GO",
+    "Gene Ontology",
+    "Minerva",
+    "Noctua",
+    "bbop",
+    "client",
+    "graph",
+    "math",
+    "mathematics",
+    "node",
+    "npm",
+    "server"
+  ],
+  "homepage": "https://berkeleybop.org/",
+  "bugs": {
+    "url": "https://github.com/berkeleybop/bbop-js-monorepo/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "SJC <sjcarbon@lbl.gov>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berkeleybop/bbop-js-monorepo.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/noctua.mjs",
+      "require": "./dist/noctua.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown --format esm --format cjs src/noctua.js",
+    "prepack": "npm run build",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "bbop-core": "^0.0.6",
+    "bbop-graph": "^0.0.21",
+    "class-expression": "^0.0.13",
+    "underscore": "^1.13.8"
+  },
+  "devDependencies": {
+    "chai": "^6.2.2"
+  },
+  "engines": {
+    "node": ">=22 <25"
+  }
+}

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-03.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-03.json
@@ -1,0 +1,735 @@
+{
+    "packet-id": "1a88d5e89632b4",
+    "uid": "GOC:sjc",
+    "intention": "query",
+    "signal": "rebuild",
+    "message-type": "success",
+    "message": "success",
+    "data": {
+        "id": "gomodel:5525a0fc00000001",
+        "annotations": [
+            {
+                "key": "title",
+                "value": "Consistency Paper March dph"
+            },
+            {
+                "key": "contributor",
+                "value": "http://orcid.org/0000-0001-7476-6306"
+            },
+            {
+                "key": "contributor",
+                "value": "GOC:kmv"
+            },
+            {
+                "key": "date",
+                "value": "2015-04-10"
+            }
+        ],
+        "facts": [
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
+                "property": "RO:0002406",
+                "object": "gomodel:5525a0fc00000001/5525a0fc0000008",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000009",
+                "property": "RO:0002406",
+                "object": "gomodel:5525a0fc00000001/5525a0fc0000010",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000440",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000009",
+                "property": "RO:0002408",
+                "object": "gomodel:5525a0fc00000001/5525a0fc0000008",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000441",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000008",
+                "property": "RO:0002333",
+                "object": "obo:#5525a0fc00000001%2F5595c4cb00000436",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
+                "property": "BFO:0000066",
+                "object": "obo:#5525a0fc00000001%2F5595c4cb00000430",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000009",
+                "property": "RO:0002333",
+                "object": "obo:#5525a0fc00000001%2F5595c4cb00000434",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
+                "property": "RO:0002333",
+                "object": "obo:#5525a0fc00000001%2F5595c4cb00000427",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-14"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
+                "property": "RO:0002408",
+                "object": "gomodel:5525a0fc00000001/5525a0fc0000009",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000439",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-14"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000010",
+                "property": "RO:0002333",
+                "object": "obo:#5525a0fc00000001%2F5595c4cb00000438",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
+                "property": "RO:0002333",
+                "object": "obo:#5525a0fc00000001%2F5595c4cb00000432",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
+                "property": "RO:0002233",
+                "object": "obo:#5525a0fc00000001%2F5595c4cb00000428",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-14"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
+                "property": "RO:0002333",
+                "object": "obo:#5525a0fc00000001%2F5595c4cb00000431",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
+                "property": "obo:GOREL_0002001",
+                "object": "obo:#5525a0fc00000001%2F5595c4cb00000426",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-14"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
+                "property": "RO:0002406",
+                "object": "gomodel:5525a0fc00000001/5525a0fc0000012",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kmv"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-20"
+                    }
+                ]
+            }
+        ],
+        "individuals": [
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000439",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:12048186"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000438",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "SGD:S000004529",
+                        "label": "TEM1"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000437",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000148",
+                        "label": "in vitro binding evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:12048186"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000436",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "SGD:S000004529",
+                        "label": "TEM1"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000435",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000005",
+                        "label": "enzyme assay evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:12048186"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000434",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "SGD:S000003814",
+                        "label": "BFA1"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000433",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000005",
+                        "label": "enzyme assay evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:12048186"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000432",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "SGD:S000003814",
+                        "label": "BFA1"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000431",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "SGD:S000004659",
+                        "label": "BUB2"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000430",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:1902773",
+                        "label": "GTPase activator complex"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5525a0fc00000001/5525a0fc0000012",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005096",
+                        "label": "GTPase activator activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "evidence",
+                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000429",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5525a0fc00000001/5525a0fc0000010",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005525",
+                        "label": "GTP binding"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "evidence",
+                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000437",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000428",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "SGD:S000003814",
+                        "label": "BFA1"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-14"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000441",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:12048186"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000440",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:12048186"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000429",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:12048186"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5525a0fc00000001/5525a0fc0000023",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005515",
+                        "label": "protein binding"
+                    }
+                ],
+                "inferred-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0098772",
+                        "label": "molecular function regulator"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005515",
+                        "label": "protein binding"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000425",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-14"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000427",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "SGD:S000004659",
+                        "label": "BUB2"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-04-14"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000426",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:1990334",
+                        "label": "Bfa1-Bub2 complex"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-14"
+                    }
+                ]
+            },
+            {
+                "id": "obo:#5525a0fc00000001%2F5595c4cb00000425",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000021",
+                        "label": "physical interaction evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:12048186"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5525a0fc00000001/5525a0fc0000009",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005095",
+                        "label": "GTPase inhibitor activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000433",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5525a0fc00000001/5525a0fc0000008",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003924",
+                        "label": "GTPase activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-04-13"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "evidence",
+                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000435",
+                        "value-type": "IRI"
+                    }
+                ]
+            }
+        ],
+        "properties": [
+            {
+                "type": "property",
+                "id": "RO:0002233",
+                "label": "has input"
+            },
+            {
+                "type": "property",
+                "id": "BFO:0000066",
+                "label": "occurs in"
+            },
+            {
+                "type": "property",
+                "id": "RO:0002408",
+                "label": "directly inhibits"
+            },
+            {
+                "type": "property",
+                "id": "RO:0002406",
+                "label": "directly activates"
+            },
+            {
+                "type": "property",
+                "id": "obo:GOREL_0002001",
+                "label": "results_in_assembly_of"
+            },
+            {
+                "type": "property",
+                "id": "RO:0002333",
+                "label": "enabled_by"
+            }
+        ]
+    }
+}

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-03.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-03.json
@@ -1,735 +1,735 @@
 {
-    "packet-id": "1a88d5e89632b4",
-    "uid": "GOC:sjc",
-    "intention": "query",
-    "signal": "rebuild",
-    "message-type": "success",
-    "message": "success",
-    "data": {
-        "id": "gomodel:5525a0fc00000001",
+  "packet-id": "1a88d5e89632b4",
+  "uid": "GOC:sjc",
+  "intention": "query",
+  "signal": "rebuild",
+  "message-type": "success",
+  "message": "success",
+  "data": {
+    "id": "gomodel:5525a0fc00000001",
+    "annotations": [
+      {
+        "key": "title",
+        "value": "Consistency Paper March dph"
+      },
+      {
+        "key": "contributor",
+        "value": "http://orcid.org/0000-0001-7476-6306"
+      },
+      {
+        "key": "contributor",
+        "value": "GOC:kmv"
+      },
+      {
+        "key": "date",
+        "value": "2015-04-10"
+      }
+    ],
+    "facts": [
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
+        "property": "RO:0002406",
+        "object": "gomodel:5525a0fc00000001/5525a0fc0000008",
         "annotations": [
-            {
-                "key": "title",
-                "value": "Consistency Paper March dph"
-            },
-            {
-                "key": "contributor",
-                "value": "http://orcid.org/0000-0001-7476-6306"
-            },
-            {
-                "key": "contributor",
-                "value": "GOC:kmv"
-            },
-            {
-                "key": "date",
-                "value": "2015-04-10"
-            }
-        ],
-        "facts": [
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
-                "property": "RO:0002406",
-                "object": "gomodel:5525a0fc00000001/5525a0fc0000008",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000009",
-                "property": "RO:0002406",
-                "object": "gomodel:5525a0fc00000001/5525a0fc0000010",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000440",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000009",
-                "property": "RO:0002408",
-                "object": "gomodel:5525a0fc00000001/5525a0fc0000008",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000441",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000008",
-                "property": "RO:0002333",
-                "object": "obo:#5525a0fc00000001%2F5595c4cb00000436",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
-                "property": "BFO:0000066",
-                "object": "obo:#5525a0fc00000001%2F5595c4cb00000430",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000009",
-                "property": "RO:0002333",
-                "object": "obo:#5525a0fc00000001%2F5595c4cb00000434",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
-                "property": "RO:0002333",
-                "object": "obo:#5525a0fc00000001%2F5595c4cb00000427",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-14"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
-                "property": "RO:0002408",
-                "object": "gomodel:5525a0fc00000001/5525a0fc0000009",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000439",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-14"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000010",
-                "property": "RO:0002333",
-                "object": "obo:#5525a0fc00000001%2F5595c4cb00000438",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
-                "property": "RO:0002333",
-                "object": "obo:#5525a0fc00000001%2F5595c4cb00000432",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
-                "property": "RO:0002233",
-                "object": "obo:#5525a0fc00000001%2F5595c4cb00000428",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-14"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
-                "property": "RO:0002333",
-                "object": "obo:#5525a0fc00000001%2F5595c4cb00000431",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
-                "property": "obo:GOREL_0002001",
-                "object": "obo:#5525a0fc00000001%2F5595c4cb00000426",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-14"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
-                "property": "RO:0002406",
-                "object": "gomodel:5525a0fc00000001/5525a0fc0000012",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kmv"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-20"
-                    }
-                ]
-            }
-        ],
-        "individuals": [
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000439",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:12048186"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000438",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "SGD:S000004529",
-                        "label": "TEM1"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000437",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000148",
-                        "label": "in vitro binding evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:12048186"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000436",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "SGD:S000004529",
-                        "label": "TEM1"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000435",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000005",
-                        "label": "enzyme assay evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:12048186"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000434",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "SGD:S000003814",
-                        "label": "BFA1"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000433",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000005",
-                        "label": "enzyme assay evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:12048186"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000432",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "SGD:S000003814",
-                        "label": "BFA1"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000431",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "SGD:S000004659",
-                        "label": "BUB2"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000430",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:1902773",
-                        "label": "GTPase activator complex"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5525a0fc00000001/5525a0fc0000012",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005096",
-                        "label": "GTPase activator activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "evidence",
-                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000429",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5525a0fc00000001/5525a0fc0000010",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005525",
-                        "label": "GTP binding"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "evidence",
-                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000437",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000428",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "SGD:S000003814",
-                        "label": "BFA1"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-14"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000441",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:12048186"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000440",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:12048186"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000429",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:12048186"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5525a0fc00000001/5525a0fc0000023",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005515",
-                        "label": "protein binding"
-                    }
-                ],
-                "inferred-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0098772",
-                        "label": "molecular function regulator"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005515",
-                        "label": "protein binding"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000425",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-14"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000427",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "SGD:S000004659",
-                        "label": "BUB2"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-04-14"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000426",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:1990334",
-                        "label": "Bfa1-Bub2 complex"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-14"
-                    }
-                ]
-            },
-            {
-                "id": "obo:#5525a0fc00000001%2F5595c4cb00000425",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000021",
-                        "label": "physical interaction evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:12048186"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5525a0fc00000001/5525a0fc0000009",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005095",
-                        "label": "GTPase inhibitor activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000433",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5525a0fc00000001/5525a0fc0000008",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003924",
-                        "label": "GTPase activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-04-13"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "evidence",
-                        "value": "obo:#5525a0fc00000001%2F5595c4cb00000435",
-                        "value-type": "IRI"
-                    }
-                ]
-            }
-        ],
-        "properties": [
-            {
-                "type": "property",
-                "id": "RO:0002233",
-                "label": "has input"
-            },
-            {
-                "type": "property",
-                "id": "BFO:0000066",
-                "label": "occurs in"
-            },
-            {
-                "type": "property",
-                "id": "RO:0002408",
-                "label": "directly inhibits"
-            },
-            {
-                "type": "property",
-                "id": "RO:0002406",
-                "label": "directly activates"
-            },
-            {
-                "type": "property",
-                "id": "obo:GOREL_0002001",
-                "label": "results_in_assembly_of"
-            },
-            {
-                "type": "property",
-                "id": "RO:0002333",
-                "label": "enabled_by"
-            }
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
         ]
-    }
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000009",
+        "property": "RO:0002406",
+        "object": "gomodel:5525a0fc00000001/5525a0fc0000010",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "obo:#5525a0fc00000001%2F5595c4cb00000440",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000009",
+        "property": "RO:0002408",
+        "object": "gomodel:5525a0fc00000001/5525a0fc0000008",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "obo:#5525a0fc00000001%2F5595c4cb00000441",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000008",
+        "property": "RO:0002333",
+        "object": "obo:#5525a0fc00000001%2F5595c4cb00000436",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
+        "property": "BFO:0000066",
+        "object": "obo:#5525a0fc00000001%2F5595c4cb00000430",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000009",
+        "property": "RO:0002333",
+        "object": "obo:#5525a0fc00000001%2F5595c4cb00000434",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
+        "property": "RO:0002333",
+        "object": "obo:#5525a0fc00000001%2F5595c4cb00000427",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-14"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
+        "property": "RO:0002408",
+        "object": "gomodel:5525a0fc00000001/5525a0fc0000009",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "obo:#5525a0fc00000001%2F5595c4cb00000439",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-14"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000010",
+        "property": "RO:0002333",
+        "object": "obo:#5525a0fc00000001%2F5595c4cb00000438",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
+        "property": "RO:0002333",
+        "object": "obo:#5525a0fc00000001%2F5595c4cb00000432",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
+        "property": "RO:0002233",
+        "object": "obo:#5525a0fc00000001%2F5595c4cb00000428",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-14"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000012",
+        "property": "RO:0002333",
+        "object": "obo:#5525a0fc00000001%2F5595c4cb00000431",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
+        "property": "obo:GOREL_0002001",
+        "object": "obo:#5525a0fc00000001%2F5595c4cb00000426",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-14"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5525a0fc00000001/5525a0fc0000023",
+        "property": "RO:0002406",
+        "object": "gomodel:5525a0fc00000001/5525a0fc0000012",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:kmv"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-20"
+          }
+        ]
+      }
+    ],
+    "individuals": [
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000439",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:12048186"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000438",
+        "type": [
+          {
+            "type": "class",
+            "id": "SGD:S000004529",
+            "label": "TEM1"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000437",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000148",
+            "label": "in vitro binding evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:12048186"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000436",
+        "type": [
+          {
+            "type": "class",
+            "id": "SGD:S000004529",
+            "label": "TEM1"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000435",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000005",
+            "label": "enzyme assay evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:12048186"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000434",
+        "type": [
+          {
+            "type": "class",
+            "id": "SGD:S000003814",
+            "label": "BFA1"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000433",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000005",
+            "label": "enzyme assay evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:12048186"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000432",
+        "type": [
+          {
+            "type": "class",
+            "id": "SGD:S000003814",
+            "label": "BFA1"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000431",
+        "type": [
+          {
+            "type": "class",
+            "id": "SGD:S000004659",
+            "label": "BUB2"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000430",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:1902773",
+            "label": "GTPase activator complex"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5525a0fc00000001/5525a0fc0000012",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005096",
+            "label": "GTPase activator activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "evidence",
+            "value": "obo:#5525a0fc00000001%2F5595c4cb00000429",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5525a0fc00000001/5525a0fc0000010",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005525",
+            "label": "GTP binding"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "evidence",
+            "value": "obo:#5525a0fc00000001%2F5595c4cb00000437",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000428",
+        "type": [
+          {
+            "type": "class",
+            "id": "SGD:S000003814",
+            "label": "BFA1"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-14"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000441",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:12048186"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000440",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:12048186"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000429",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:12048186"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5525a0fc00000001/5525a0fc0000023",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005515",
+            "label": "protein binding"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "GO:0098772",
+            "label": "molecular function regulator"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005515",
+            "label": "protein binding"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "obo:#5525a0fc00000001%2F5595c4cb00000425",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-14"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000427",
+        "type": [
+          {
+            "type": "class",
+            "id": "SGD:S000004659",
+            "label": "BUB2"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-04-14"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000426",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:1990334",
+            "label": "Bfa1-Bub2 complex"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-14"
+          }
+        ]
+      },
+      {
+        "id": "obo:#5525a0fc00000001%2F5595c4cb00000425",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000021",
+            "label": "physical interaction evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:12048186"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5525a0fc00000001/5525a0fc0000009",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005095",
+            "label": "GTPase inhibitor activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "obo:#5525a0fc00000001%2F5595c4cb00000433",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5525a0fc00000001/5525a0fc0000008",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0003924",
+            "label": "GTPase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-04-13"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "evidence",
+            "value": "obo:#5525a0fc00000001%2F5595c4cb00000435",
+            "value-type": "IRI"
+          }
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "type": "property",
+        "id": "RO:0002233",
+        "label": "has input"
+      },
+      {
+        "type": "property",
+        "id": "BFO:0000066",
+        "label": "occurs in"
+      },
+      {
+        "type": "property",
+        "id": "RO:0002408",
+        "label": "directly inhibits"
+      },
+      {
+        "type": "property",
+        "id": "RO:0002406",
+        "label": "directly activates"
+      },
+      {
+        "type": "property",
+        "id": "obo:GOREL_0002001",
+        "label": "results_in_assembly_of"
+      },
+      {
+        "type": "property",
+        "id": "RO:0002333",
+        "label": "enabled_by"
+      }
+    ]
+  }
 }

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-04.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-04.json
@@ -1,0 +1,388 @@
+{
+    "packet-id": "3fac87b8e57a165",
+    "uid": "GOC:kltm",
+    "intention": "query",
+    "signal": "rebuild",
+    "message-type": "success",
+    "message": "success",
+    "data": {
+        "id": "gomodel:55ad81df00000001",
+        "modified-p": false,
+        "annotations": [
+            {
+                "key": "comment",
+                "value": "Model to be used for experiments and testing."
+            },
+            {
+                "key": "date",
+                "value": "2015-08-17"
+            },
+            {
+                "key": "title",
+                "value": "Scratch"
+            },
+            {
+                "key": "contributor",
+                "value": "GOC:sjc"
+            },
+            {
+                "key": "contributor",
+                "value": "GOC:kltm"
+            },
+            {
+                "key": "state",
+                "value": "development"
+            }
+        ],
+        "facts": [
+            {
+                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+                "property": "BFO:0000050",
+                "object": "gomodel:55ad81df00000001/55afdcd900000001",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-07-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+                "property": "RO:0002333",
+                "object": "gomodel:55ad81df00000001/55ad81df00000005",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-07-20"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+                "property": "BFO:0000066",
+                "object": "gomodel:55ad81df00000001/55ad81df00000006",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:55ad81df00000001/55d24a8b00000002",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    }
+                ]
+            }
+        ],
+        "individuals": [
+            {
+                "id": "gomodel:55ad81df00000001/55d24a8b00000003",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000359",
+                        "label": "differential geneset expression evidence from RNA-seq experiment (GSEA, Fisher-exact)"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "310"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:0123456"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "17"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55d24a8b00000002",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000303",
+                        "label": "non-traceable author statement used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "199"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:9999999"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "309"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55d24a8b00000001",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000034",
+                        "label": "non-traceable author statement"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "45"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "10"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:0000000"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55afdcd900000002",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000034",
+                        "label": "non-traceable author statement"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "12"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "335"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:HAHAHA"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55afdcd900000001",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0009015",
+                        "label": "N-succinylarginine dihydrolase activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:55ad81df00000001/55afdcd900000002",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "104"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "336"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55ad81df00000006",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0043670",
+                        "label": "foot layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "17"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "236"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55ad81df00000005",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "FB:FBgn0263395",
+                        "label": "hppy"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "236"
+                    },
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:55ad81df00000001/55d24a8b00000003",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "199"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55ad81df00000004",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0033042",
+                        "label": "umami taste receptor activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:55ad81df00000001/55d24a8b00000001",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "45"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "102"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    }
+                ]
+            }
+        ],
+        "properties": [
+            {
+                "type": "property",
+                "id": "BFO:0000066",
+                "label": "occurs in"
+            },
+            {
+                "type": "property",
+                "id": "RO:0002333",
+                "label": "enabled_by"
+            },
+            {
+                "type": "property",
+                "id": "BFO:0000050",
+                "label": "part of"
+            }
+        ]
+    }
+}

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-04.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-04.json
@@ -1,388 +1,388 @@
 {
-    "packet-id": "3fac87b8e57a165",
-    "uid": "GOC:kltm",
-    "intention": "query",
-    "signal": "rebuild",
-    "message-type": "success",
-    "message": "success",
-    "data": {
-        "id": "gomodel:55ad81df00000001",
-        "modified-p": false,
+  "packet-id": "3fac87b8e57a165",
+  "uid": "GOC:kltm",
+  "intention": "query",
+  "signal": "rebuild",
+  "message-type": "success",
+  "message": "success",
+  "data": {
+    "id": "gomodel:55ad81df00000001",
+    "modified-p": false,
+    "annotations": [
+      {
+        "key": "comment",
+        "value": "Model to be used for experiments and testing."
+      },
+      {
+        "key": "date",
+        "value": "2015-08-17"
+      },
+      {
+        "key": "title",
+        "value": "Scratch"
+      },
+      {
+        "key": "contributor",
+        "value": "GOC:sjc"
+      },
+      {
+        "key": "contributor",
+        "value": "GOC:kltm"
+      },
+      {
+        "key": "state",
+        "value": "development"
+      }
+    ],
+    "facts": [
+      {
+        "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+        "property": "BFO:0000050",
+        "object": "gomodel:55ad81df00000001/55afdcd900000001",
         "annotations": [
-            {
-                "key": "comment",
-                "value": "Model to be used for experiments and testing."
-            },
-            {
-                "key": "date",
-                "value": "2015-08-17"
-            },
-            {
-                "key": "title",
-                "value": "Scratch"
-            },
-            {
-                "key": "contributor",
-                "value": "GOC:sjc"
-            },
-            {
-                "key": "contributor",
-                "value": "GOC:kltm"
-            },
-            {
-                "key": "state",
-                "value": "development"
-            }
-        ],
-        "facts": [
-            {
-                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
-                "property": "BFO:0000050",
-                "object": "gomodel:55ad81df00000001/55afdcd900000001",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-07-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
-                "property": "RO:0002333",
-                "object": "gomodel:55ad81df00000001/55ad81df00000005",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-07-20"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
-                "property": "BFO:0000066",
-                "object": "gomodel:55ad81df00000001/55ad81df00000006",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:55ad81df00000001/55d24a8b00000002",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    }
-                ]
-            }
-        ],
-        "individuals": [
-            {
-                "id": "gomodel:55ad81df00000001/55d24a8b00000003",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000359",
-                        "label": "differential geneset expression evidence from RNA-seq experiment (GSEA, Fisher-exact)"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "310"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:0123456"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "17"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55d24a8b00000002",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000303",
-                        "label": "non-traceable author statement used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "199"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:9999999"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "309"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55d24a8b00000001",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000034",
-                        "label": "non-traceable author statement"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "45"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "10"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:0000000"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55afdcd900000002",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000034",
-                        "label": "non-traceable author statement"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "12"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "335"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:HAHAHA"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55afdcd900000001",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0009015",
-                        "label": "N-succinylarginine dihydrolase activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:55ad81df00000001/55afdcd900000002",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "104"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "336"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55ad81df00000006",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0043670",
-                        "label": "foot layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "17"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "236"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55ad81df00000005",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "FB:FBgn0263395",
-                        "label": "hppy"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "236"
-                    },
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:55ad81df00000001/55d24a8b00000003",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "199"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55ad81df00000004",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0033042",
-                        "label": "umami taste receptor activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:55ad81df00000001/55d24a8b00000001",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "45"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "102"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    }
-                ]
-            }
-        ],
-        "properties": [
-            {
-                "type": "property",
-                "id": "BFO:0000066",
-                "label": "occurs in"
-            },
-            {
-                "type": "property",
-                "id": "RO:0002333",
-                "label": "enabled_by"
-            },
-            {
-                "type": "property",
-                "id": "BFO:0000050",
-                "label": "part of"
-            }
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "date",
+            "value": "2015-07-22"
+          }
         ]
-    }
+      },
+      {
+        "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+        "property": "RO:0002333",
+        "object": "gomodel:55ad81df00000001/55ad81df00000005",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "date",
+            "value": "2015-07-20"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+        "property": "BFO:0000066",
+        "object": "gomodel:55ad81df00000001/55ad81df00000006",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:55ad81df00000001/55d24a8b00000002",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          }
+        ]
+      }
+    ],
+    "individuals": [
+      {
+        "id": "gomodel:55ad81df00000001/55d24a8b00000003",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000359",
+            "label": "differential geneset expression evidence from RNA-seq experiment (GSEA, Fisher-exact)"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "310"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "source",
+            "value": "PMID:0123456"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55d24a8b00000002",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000303",
+            "label": "non-traceable author statement used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "199"
+          },
+          {
+            "key": "source",
+            "value": "PMID:9999999"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "309"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55d24a8b00000001",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000034",
+            "label": "non-traceable author statement"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "45"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "10"
+          },
+          {
+            "key": "source",
+            "value": "PMID:0000000"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55afdcd900000002",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000034",
+            "label": "non-traceable author statement"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "12"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "335"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "source",
+            "value": "PMID:HAHAHA"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55afdcd900000001",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0009015",
+            "label": "N-succinylarginine dihydrolase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:55ad81df00000001/55afdcd900000002",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "104"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "336"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55ad81df00000006",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0043670",
+            "label": "foot layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "17"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "236"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55ad81df00000005",
+        "type": [
+          {
+            "type": "class",
+            "id": "FB:FBgn0263395",
+            "label": "hppy"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "236"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:55ad81df00000001/55d24a8b00000003",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "199"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55ad81df00000004",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0033042",
+            "label": "umami taste receptor activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:55ad81df00000001/55d24a8b00000001",
+            "value-type": "IRI"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "45"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "102"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          }
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "type": "property",
+        "id": "BFO:0000066",
+        "label": "occurs in"
+      },
+      {
+        "type": "property",
+        "id": "RO:0002333",
+        "label": "enabled_by"
+      },
+      {
+        "type": "property",
+        "id": "BFO:0000050",
+        "label": "part of"
+      }
+    ]
+  }
 }

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-05.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-05.json
@@ -1,0 +1,543 @@
+{
+    "packet-id": "443a6e263a9b0e",
+    "uid": "GOC:kltm",
+    "intention": "query",
+    "signal": "rebuild",
+    "message-type": "success",
+    "message": "success",
+    "data": {
+        "id": "gomodel:55ad81df00000001",
+        "modified-p": true,
+        "annotations": [
+            {
+                "key": "comment",
+                "value": "Model to be used for experiments and testing."
+            },
+            {
+                "key": "title",
+                "value": "Scratch"
+            },
+            {
+                "key": "contributor",
+                "value": "http://orcid.org/0000-0002-6601-2165"
+            },
+            {
+                "key": "contributor",
+                "value": "GOC:sjc"
+            },
+            {
+                "key": "contributor",
+                "value": "GOC:kltm"
+            },
+            {
+                "key": "state",
+                "value": "development"
+            },
+            {
+                "key": "date",
+                "value": "2015-08-19"
+            }
+        ],
+        "facts": [
+            {
+                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+                "property": "RO:0002333",
+                "object": "gomodel:55ad81df00000001/55ad81df00000005",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-07-20"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:55ad81df00000001/55d23de300000002",
+                "property": "BFO:0000066",
+                "object": "gomodel:55ad81df00000001/55d23de300000004",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-18"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+                "property": "BFO:0000050",
+                "object": "gomodel:55ad81df00000001/55afdcd900000001",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-07-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+                "property": "BFO:0000066",
+                "object": "gomodel:55ad81df00000001/55ad81df00000006",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:55ad81df00000001/55d24a8b00000002",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:55ad81df00000001/55d23de300000002",
+                "property": "RO:0002333",
+                "object": "gomodel:55ad81df00000001/55d23de300000003",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:55ad81df00000001/55d23de300000008",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-18"
+                    }
+                ]
+            }
+        ],
+        "individuals": [
+            {
+                "id": "gomodel:55ad81df00000001/55d24a8b00000003",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000359",
+                        "label": "differential geneset expression evidence from RNA-seq experiment (GSEA, Fisher-exact)"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "310"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:0123456"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "17"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55d24a8b00000002",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000303",
+                        "label": "non-traceable author statement used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:9999999"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "199"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "309"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55d24a8b00000001",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000034",
+                        "label": "non-traceable author statement"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "45"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "10"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:0000000"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55afdcd900000002",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000034",
+                        "label": "non-traceable author statement"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "12"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "335"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:HAHAHA"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55d23de300000004",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010403",
+                        "label": "brain marginal zone"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "975"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-18"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55d23de300000003",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "AspGD:ASPL0000098579",
+                        "label": "zipA"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "33"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "708"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-18"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55d23de300000002",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0097296",
+                        "label": "activation of cysteine-type endopeptidase activity involved in apoptotic signaling pathway"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-08-18"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "228"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "572"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55d23de300000008",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000176",
+                        "label": "mutant visible phenotype evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-08-18"
+                    },
+                    {
+                        "key": "source",
+                        "value": "CJM:123"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55ad81df00000006",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0043670",
+                        "label": "foot layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "17"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "236"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55ad81df00000005",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "FB:FBgn0263395",
+                        "label": "hppy"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2015-08-17"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "236"
+                    },
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:55ad81df00000001/55d24a8b00000003",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "199"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55ad81df00000004",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0033042",
+                        "label": "umami taste receptor activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "64"
+                    },
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:55ad81df00000001/55d24a8b00000001",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-18"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "62"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/55afdcd900000001",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0009015",
+                        "label": "N-succinylarginine dihydrolase activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "404"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:sjc"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:55ad81df00000001/55afdcd900000002",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "76"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2015-08-18"
+                    }
+                ]
+            }
+        ],
+        "properties": [
+            {
+                "type": "property",
+                "id": "BFO:0000066",
+                "label": "occurs in"
+            },
+            {
+                "type": "property",
+                "id": "BFO:0000050",
+                "label": "part of"
+            },
+            {
+                "type": "property",
+                "id": "RO:0002333",
+                "label": "enabled_by"
+            }
+        ]
+    }
+}

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-05.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-05.json
@@ -1,543 +1,543 @@
 {
-    "packet-id": "443a6e263a9b0e",
-    "uid": "GOC:kltm",
-    "intention": "query",
-    "signal": "rebuild",
-    "message-type": "success",
-    "message": "success",
-    "data": {
-        "id": "gomodel:55ad81df00000001",
-        "modified-p": true,
+  "packet-id": "443a6e263a9b0e",
+  "uid": "GOC:kltm",
+  "intention": "query",
+  "signal": "rebuild",
+  "message-type": "success",
+  "message": "success",
+  "data": {
+    "id": "gomodel:55ad81df00000001",
+    "modified-p": true,
+    "annotations": [
+      {
+        "key": "comment",
+        "value": "Model to be used for experiments and testing."
+      },
+      {
+        "key": "title",
+        "value": "Scratch"
+      },
+      {
+        "key": "contributor",
+        "value": "http://orcid.org/0000-0002-6601-2165"
+      },
+      {
+        "key": "contributor",
+        "value": "GOC:sjc"
+      },
+      {
+        "key": "contributor",
+        "value": "GOC:kltm"
+      },
+      {
+        "key": "state",
+        "value": "development"
+      },
+      {
+        "key": "date",
+        "value": "2015-08-19"
+      }
+    ],
+    "facts": [
+      {
+        "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+        "property": "RO:0002333",
+        "object": "gomodel:55ad81df00000001/55ad81df00000005",
         "annotations": [
-            {
-                "key": "comment",
-                "value": "Model to be used for experiments and testing."
-            },
-            {
-                "key": "title",
-                "value": "Scratch"
-            },
-            {
-                "key": "contributor",
-                "value": "http://orcid.org/0000-0002-6601-2165"
-            },
-            {
-                "key": "contributor",
-                "value": "GOC:sjc"
-            },
-            {
-                "key": "contributor",
-                "value": "GOC:kltm"
-            },
-            {
-                "key": "state",
-                "value": "development"
-            },
-            {
-                "key": "date",
-                "value": "2015-08-19"
-            }
-        ],
-        "facts": [
-            {
-                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
-                "property": "RO:0002333",
-                "object": "gomodel:55ad81df00000001/55ad81df00000005",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-07-20"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:55ad81df00000001/55d23de300000002",
-                "property": "BFO:0000066",
-                "object": "gomodel:55ad81df00000001/55d23de300000004",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-18"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
-                "property": "BFO:0000050",
-                "object": "gomodel:55ad81df00000001/55afdcd900000001",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-07-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:55ad81df00000001/55ad81df00000004",
-                "property": "BFO:0000066",
-                "object": "gomodel:55ad81df00000001/55ad81df00000006",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:55ad81df00000001/55d24a8b00000002",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:55ad81df00000001/55d23de300000002",
-                "property": "RO:0002333",
-                "object": "gomodel:55ad81df00000001/55d23de300000003",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:55ad81df00000001/55d23de300000008",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-18"
-                    }
-                ]
-            }
-        ],
-        "individuals": [
-            {
-                "id": "gomodel:55ad81df00000001/55d24a8b00000003",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000359",
-                        "label": "differential geneset expression evidence from RNA-seq experiment (GSEA, Fisher-exact)"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "310"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:0123456"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "17"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55d24a8b00000002",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000303",
-                        "label": "non-traceable author statement used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:9999999"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "199"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "309"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55d24a8b00000001",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000034",
-                        "label": "non-traceable author statement"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "45"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "10"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:0000000"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55afdcd900000002",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000034",
-                        "label": "non-traceable author statement"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "12"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "335"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:HAHAHA"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55d23de300000004",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010403",
-                        "label": "brain marginal zone"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "975"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-18"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55d23de300000003",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "AspGD:ASPL0000098579",
-                        "label": "zipA"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "33"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "708"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-18"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55d23de300000002",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0097296",
-                        "label": "activation of cysteine-type endopeptidase activity involved in apoptotic signaling pathway"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-08-18"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "228"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "572"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55d23de300000008",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000176",
-                        "label": "mutant visible phenotype evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-08-18"
-                    },
-                    {
-                        "key": "source",
-                        "value": "CJM:123"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55ad81df00000006",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0043670",
-                        "label": "foot layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "17"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "236"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55ad81df00000005",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "FB:FBgn0263395",
-                        "label": "hppy"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2015-08-17"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "236"
-                    },
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:55ad81df00000001/55d24a8b00000003",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "199"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55ad81df00000004",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0033042",
-                        "label": "umami taste receptor activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "64"
-                    },
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:55ad81df00000001/55d24a8b00000001",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-18"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "62"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/55afdcd900000001",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0009015",
-                        "label": "N-succinylarginine dihydrolase activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "404"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:sjc"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:55ad81df00000001/55afdcd900000002",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "76"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2015-08-18"
-                    }
-                ]
-            }
-        ],
-        "properties": [
-            {
-                "type": "property",
-                "id": "BFO:0000066",
-                "label": "occurs in"
-            },
-            {
-                "type": "property",
-                "id": "BFO:0000050",
-                "label": "part of"
-            },
-            {
-                "type": "property",
-                "id": "RO:0002333",
-                "label": "enabled_by"
-            }
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "date",
+            "value": "2015-07-20"
+          }
         ]
-    }
+      },
+      {
+        "subject": "gomodel:55ad81df00000001/55d23de300000002",
+        "property": "BFO:0000066",
+        "object": "gomodel:55ad81df00000001/55d23de300000004",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-18"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+        "property": "BFO:0000050",
+        "object": "gomodel:55ad81df00000001/55afdcd900000001",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "date",
+            "value": "2015-07-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:55ad81df00000001/55ad81df00000004",
+        "property": "BFO:0000066",
+        "object": "gomodel:55ad81df00000001/55ad81df00000006",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:55ad81df00000001/55d24a8b00000002",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:55ad81df00000001/55d23de300000002",
+        "property": "RO:0002333",
+        "object": "gomodel:55ad81df00000001/55d23de300000003",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:55ad81df00000001/55d23de300000008",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-18"
+          }
+        ]
+      }
+    ],
+    "individuals": [
+      {
+        "id": "gomodel:55ad81df00000001/55d24a8b00000003",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000359",
+            "label": "differential geneset expression evidence from RNA-seq experiment (GSEA, Fisher-exact)"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "310"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "source",
+            "value": "PMID:0123456"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55d24a8b00000002",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000303",
+            "label": "non-traceable author statement used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "source",
+            "value": "PMID:9999999"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "199"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "309"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55d24a8b00000001",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000034",
+            "label": "non-traceable author statement"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "45"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "10"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "source",
+            "value": "PMID:0000000"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55afdcd900000002",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000034",
+            "label": "non-traceable author statement"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "12"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "335"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "source",
+            "value": "PMID:HAHAHA"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55d23de300000004",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010403",
+            "label": "brain marginal zone"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "975"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-18"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55d23de300000003",
+        "type": [
+          {
+            "type": "class",
+            "id": "AspGD:ASPL0000098579",
+            "label": "zipA"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "33"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "708"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-18"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55d23de300000002",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0097296",
+            "label": "activation of cysteine-type endopeptidase activity involved in apoptotic signaling pathway"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-08-18"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "228"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "572"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55d23de300000008",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000176",
+            "label": "mutant visible phenotype evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-08-18"
+          },
+          {
+            "key": "source",
+            "value": "CJM:123"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55ad81df00000006",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0043670",
+            "label": "foot layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "17"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "236"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55ad81df00000005",
+        "type": [
+          {
+            "type": "class",
+            "id": "FB:FBgn0263395",
+            "label": "hppy"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2015-08-17"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "236"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:55ad81df00000001/55d24a8b00000003",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "199"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55ad81df00000004",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0033042",
+            "label": "umami taste receptor activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "64"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:55ad81df00000001/55d24a8b00000001",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-18"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "62"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/55afdcd900000001",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0009015",
+            "label": "N-succinylarginine dihydrolase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "404"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:sjc"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:55ad81df00000001/55afdcd900000002",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "76"
+          },
+          {
+            "key": "date",
+            "value": "2015-08-18"
+          }
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "type": "property",
+        "id": "BFO:0000066",
+        "label": "occurs in"
+      },
+      {
+        "type": "property",
+        "id": "BFO:0000050",
+        "label": "part of"
+      },
+      {
+        "type": "property",
+        "id": "RO:0002333",
+        "label": "enabled_by"
+      }
+    ]
+  }
 }

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-06.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-06.json
@@ -1,0 +1,116 @@
+{
+    "packet-id": "5083d513338018",
+    "uid": "GOC:kltm",
+    "is-reasoned": true,
+    "intention": "query",
+    "signal": "rebuild",
+    "message-type": "success",
+    "message": "success",
+    "data": {
+        "id": "gomodel:55ad81df00000001",
+        "modified-p": true,
+        "annotations": [
+            {
+                "key": "comment",
+                "value": "Model to be used for experiments and testing."
+            },
+            {
+                "key": "title",
+                "value": "Scratch"
+            },
+            {
+                "key": "contributor",
+                "value": "http://orcid.org/0000-0002-6601-2165"
+            },
+            {
+                "key": "contributor",
+                "value": "GOC:sjc"
+            },
+            {
+                "key": "contributor",
+                "value": "GOC:kltm"
+            },
+            {
+                "key": "state",
+                "value": "development"
+            },
+            {
+                "key": "date",
+                "value": "2016-01-08"
+            }
+        ],
+        "facts": [
+            {
+                "subject": "gomodel:55ad81df00000001/56902be400000001",
+                "property": "BFO:0000050",
+                "object": "gomodel:55ad81df00000001/56902be400000002",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-01-08"
+                    }
+                ]
+            }
+        ],
+        "individuals": [
+            {
+                "id": "gomodel:55ad81df00000001/56902be400000002",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0000278",
+                        "label": "mitotic cell cycle"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-01-08"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:55ad81df00000001/56902be400000001",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0051231",
+                        "label": "spindle elongation"
+                    }
+                ],
+                "inferred-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0000022",
+                        "label": "mitotic spindle elongation"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-01-08"
+                    }
+                ]
+            }
+        ],
+        "properties": [
+            {
+                "type": "property",
+                "id": "BFO:0000050",
+                "label": "part of"
+            }
+        ]
+    }
+}

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-06.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-06.json
@@ -1,116 +1,116 @@
 {
-    "packet-id": "5083d513338018",
-    "uid": "GOC:kltm",
-    "is-reasoned": true,
-    "intention": "query",
-    "signal": "rebuild",
-    "message-type": "success",
-    "message": "success",
-    "data": {
-        "id": "gomodel:55ad81df00000001",
-        "modified-p": true,
+  "packet-id": "5083d513338018",
+  "uid": "GOC:kltm",
+  "is-reasoned": true,
+  "intention": "query",
+  "signal": "rebuild",
+  "message-type": "success",
+  "message": "success",
+  "data": {
+    "id": "gomodel:55ad81df00000001",
+    "modified-p": true,
+    "annotations": [
+      {
+        "key": "comment",
+        "value": "Model to be used for experiments and testing."
+      },
+      {
+        "key": "title",
+        "value": "Scratch"
+      },
+      {
+        "key": "contributor",
+        "value": "http://orcid.org/0000-0002-6601-2165"
+      },
+      {
+        "key": "contributor",
+        "value": "GOC:sjc"
+      },
+      {
+        "key": "contributor",
+        "value": "GOC:kltm"
+      },
+      {
+        "key": "state",
+        "value": "development"
+      },
+      {
+        "key": "date",
+        "value": "2016-01-08"
+      }
+    ],
+    "facts": [
+      {
+        "subject": "gomodel:55ad81df00000001/56902be400000001",
+        "property": "BFO:0000050",
+        "object": "gomodel:55ad81df00000001/56902be400000002",
         "annotations": [
-            {
-                "key": "comment",
-                "value": "Model to be used for experiments and testing."
-            },
-            {
-                "key": "title",
-                "value": "Scratch"
-            },
-            {
-                "key": "contributor",
-                "value": "http://orcid.org/0000-0002-6601-2165"
-            },
-            {
-                "key": "contributor",
-                "value": "GOC:sjc"
-            },
-            {
-                "key": "contributor",
-                "value": "GOC:kltm"
-            },
-            {
-                "key": "state",
-                "value": "development"
-            },
-            {
-                "key": "date",
-                "value": "2016-01-08"
-            }
-        ],
-        "facts": [
-            {
-                "subject": "gomodel:55ad81df00000001/56902be400000001",
-                "property": "BFO:0000050",
-                "object": "gomodel:55ad81df00000001/56902be400000002",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-01-08"
-                    }
-                ]
-            }
-        ],
-        "individuals": [
-            {
-                "id": "gomodel:55ad81df00000001/56902be400000002",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0000278",
-                        "label": "mitotic cell cycle"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-01-08"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:55ad81df00000001/56902be400000001",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0051231",
-                        "label": "spindle elongation"
-                    }
-                ],
-                "inferred-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0000022",
-                        "label": "mitotic spindle elongation"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-01-08"
-                    }
-                ]
-            }
-        ],
-        "properties": [
-            {
-                "type": "property",
-                "id": "BFO:0000050",
-                "label": "part of"
-            }
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "date",
+            "value": "2016-01-08"
+          }
         ]
-    }
+      }
+    ],
+    "individuals": [
+      {
+        "id": "gomodel:55ad81df00000001/56902be400000002",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0000278",
+            "label": "mitotic cell cycle"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-01-08"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:55ad81df00000001/56902be400000001",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0051231",
+            "label": "spindle elongation"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "GO:0000022",
+            "label": "mitotic spindle elongation"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "date",
+            "value": "2016-01-08"
+          }
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "type": "property",
+        "id": "BFO:0000050",
+        "label": "part of"
+      }
+    ]
+  }
 }

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-07.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-07.json
@@ -1,0 +1,2935 @@
+{
+    "packet-id": "109ff8e83e4de3",
+    "is-reasoned": false,
+    "intention": "query",
+    "signal": "rebuild",
+    "message-type": "success",
+    "message": "success",
+    "data": {
+        "modified-p": false,
+        "id": "gomodel:56aac7ad00000236",
+        "individuals": [
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000250",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000249",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0002415",
+                        "label": "tail"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000247",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008544",
+                        "label": "epidermis development"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "576"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "964"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000246",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000245",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96699",
+                        "label": "Krt2 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000244",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008092",
+                        "label": "cytoskeletal protein binding"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "285.25"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "16"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000241",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000343",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:3056582"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000342",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:3056582"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000238",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96699",
+                        "label": "Krt2 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000340",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000297",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008092",
+                        "label": "cytoskeletal protein binding"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "23.75"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "520.5"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000296",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000294",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045095",
+                        "label": "keratin filament"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "579"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "363"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000293",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000291",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000290",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000339",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000338",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005198",
+                        "label": "structural molecule activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "380"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "261"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000337",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000336",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000335",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000334",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000333",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000332",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000331",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000330",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000289",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000288",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000287",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045095",
+                        "label": "keratin filament"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "211"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "46"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000286",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000285",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000284",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045109",
+                        "label": "intermediate filament organization"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "432.75"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "515"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000283",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000282",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000281",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000280",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000341",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005198",
+                        "label": "structural molecule activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "643"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "238"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000329",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000328",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000327",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000326",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000325",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000324",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000323",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000322",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000321",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:3056582"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000320",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:3056582"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000278",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000277",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045109",
+                        "label": "intermediate filament organization"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "357"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000276",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000275",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000274",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000273",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000271",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96685",
+                        "label": "Krt10 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000270",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96685",
+                        "label": "Krt10 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000319",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000318",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000317",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005198",
+                        "label": "structural molecule activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "215"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "300"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000316",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005198",
+                        "label": "structural molecule activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "184"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "510"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000315",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000316",
+                        "label": "genetic interaction evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:96699"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000314",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:3056582"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000312",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96699",
+                        "label": "Krt2 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000311",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96685",
+                        "label": "Krt10 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000269",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000270",
+                        "label": "expression evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000268",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000266",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000265",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000263",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001691",
+                        "label": "external ear"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000262",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008544",
+                        "label": "epidermis development"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "173"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "947"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000261",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003335",
+                        "label": "corneocyte development"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "772"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000237",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008092",
+                        "label": "cytoskeletal protein binding"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000308",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008092",
+                        "label": "cytoskeletal protein binding"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "757.38330078125"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "220.5"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000307",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000316",
+                        "label": "genetic interaction evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:96699"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000306",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:3056582"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000304",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000316",
+                        "label": "genetic interaction evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:96685"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000303",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000316",
+                        "label": "genetic interaction evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:96685"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000301",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96699",
+                        "label": "Krt2 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000300",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96685",
+                        "label": "Krt10 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000259",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0061436",
+                        "label": "establishment of skin barrier"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "1005"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000257",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000253",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003334",
+                        "label": "keratinocyte development"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "708"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "548"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236/56aac7ad00000252",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003334",
+                        "label": "keratinocyte development"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "4"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "549"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            }
+        ],
+        "facts": [
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
+                "property": "RO:0002233",
+                "property-label": "has input",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000301",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000307",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000334",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000335",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000285",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000289",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
+                "property": "RO:0002333",
+                "property-label": "enabled_by",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000245",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000246",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000328",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000329",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000317",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000277",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000319",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
+                "property": "RO:0002233",
+                "property-label": "has input",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000271",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000303",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000341",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000284",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000343",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000261",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000262",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000274",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
+                "property": "RO:0002233",
+                "property-label": "has input",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000312",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000315",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000262",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000263",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000276",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000330",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000331",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000252",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000262",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000275",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000332",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000333",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000252",
+                "property": "RO:0002411",
+                "property-label": "causally upstream of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000261",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000265",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000326",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000327",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
+                "property": "RO:0002333",
+                "property-label": "enabled_by",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000300",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000306",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000252",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000291",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
+                "property": "RO:0002233",
+                "property-label": "has input",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000270",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000304",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000316",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000277",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000321",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000253",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000293",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000286",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000290",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000341",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000342",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000317",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000318",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000261",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000259",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000273",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000253",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000268",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000269",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
+                "property": "RO:0002333",
+                "property-label": "enabled_by",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000311",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000314",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000324",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000325",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000247",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000249",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000250",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000338",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000339",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
+                "property": "obo:GOREL_0002006",
+                "property-label": "results_in_organization_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000294",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000296",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000322",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000323",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000336",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000337",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000252",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000266",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000281",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000316",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000320",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
+                "property": "RO:0002333",
+                "property-label": "enabled_by",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000238",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000241",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
+                "property": "obo:GOREL_0002006",
+                "property-label": "results_in_organization_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000287",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000288",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000280",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000282",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000338",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000284",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000340",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000278",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000283",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236/56aac7ad00000253",
+                "property": "BFO:0000050",
+                "property-label": "part_of",
+                "object": "gomodel:56aac7ad00000236/56aac7ad00000247",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236/56aac7ad00000257",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            }
+        ],
+        "annotations": [
+            {
+                "key": "date",
+                "value": "2016-02-22"
+            },
+            {
+                "key": "contributor",
+                "value": "http://orcid.org/0000-0001-7476-6306"
+            },
+            {
+                "key": "state",
+                "value": "development"
+            },
+            {
+                "key": "title",
+                "value": "Mouse-Krt2-epidermis"
+            }
+        ]
+    }
+}

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-07.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-07.json
@@ -1,2935 +1,2935 @@
 {
-    "packet-id": "109ff8e83e4de3",
-    "is-reasoned": false,
-    "intention": "query",
-    "signal": "rebuild",
-    "message-type": "success",
-    "message": "success",
-    "data": {
-        "modified-p": false,
-        "id": "gomodel:56aac7ad00000236",
-        "individuals": [
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000250",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000249",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0002415",
-                        "label": "tail"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000247",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008544",
-                        "label": "epidermis development"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "576"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "964"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000246",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000245",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96699",
-                        "label": "Krt2 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000244",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008092",
-                        "label": "cytoskeletal protein binding"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "285.25"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "16"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000241",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000343",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:3056582"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000342",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:3056582"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000238",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96699",
-                        "label": "Krt2 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000340",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000297",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008092",
-                        "label": "cytoskeletal protein binding"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "23.75"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "520.5"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000296",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000294",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045095",
-                        "label": "keratin filament"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "579"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "363"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000293",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000291",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000290",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000339",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000338",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005198",
-                        "label": "structural molecule activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "380"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "261"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000337",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000336",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000335",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000334",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000333",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000332",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000331",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000330",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000289",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000288",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000287",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045095",
-                        "label": "keratin filament"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "211"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "46"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000286",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000285",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000284",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045109",
-                        "label": "intermediate filament organization"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "432.75"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "515"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000283",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000282",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000281",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000280",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000341",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005198",
-                        "label": "structural molecule activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "643"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "238"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000329",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000328",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000327",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000326",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000325",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000324",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000323",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000322",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000321",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:3056582"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000320",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:3056582"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000278",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000277",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045109",
-                        "label": "intermediate filament organization"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "357"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000276",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000275",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000274",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000273",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000271",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96685",
-                        "label": "Krt10 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000270",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96685",
-                        "label": "Krt10 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000319",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000318",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000317",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005198",
-                        "label": "structural molecule activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "215"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "300"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000316",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005198",
-                        "label": "structural molecule activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "184"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "510"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000315",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000316",
-                        "label": "genetic interaction evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:96699"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000314",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:3056582"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000312",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96699",
-                        "label": "Krt2 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000311",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96685",
-                        "label": "Krt10 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000269",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000270",
-                        "label": "expression evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000268",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000266",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000265",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000263",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001691",
-                        "label": "external ear"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000262",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008544",
-                        "label": "epidermis development"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "173"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "947"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000261",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003335",
-                        "label": "corneocyte development"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "772"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000237",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008092",
-                        "label": "cytoskeletal protein binding"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000308",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008092",
-                        "label": "cytoskeletal protein binding"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "757.38330078125"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "220.5"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000307",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000316",
-                        "label": "genetic interaction evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:96699"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000306",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:3056582"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000304",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000316",
-                        "label": "genetic interaction evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:96685"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000303",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000316",
-                        "label": "genetic interaction evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:96685"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000301",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96699",
-                        "label": "Krt2 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000300",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96685",
-                        "label": "Krt10 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000259",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0061436",
-                        "label": "establishment of skin barrier"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "1005"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000257",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000253",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003334",
-                        "label": "keratinocyte development"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "708"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "548"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236/56aac7ad00000252",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003334",
-                        "label": "keratinocyte development"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "4"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "549"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            }
-        ],
-        "facts": [
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
-                "property": "RO:0002233",
-                "property-label": "has input",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000301",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000307",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000334",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000335",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000285",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000289",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
-                "property": "RO:0002333",
-                "property-label": "enabled_by",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000245",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000246",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000328",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000329",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000317",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000277",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000319",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
-                "property": "RO:0002233",
-                "property-label": "has input",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000271",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000303",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000341",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000284",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000343",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000261",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000262",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000274",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
-                "property": "RO:0002233",
-                "property-label": "has input",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000312",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000315",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000262",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000263",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000276",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000330",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000331",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000252",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000262",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000275",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000332",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000333",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000252",
-                "property": "RO:0002411",
-                "property-label": "causally upstream of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000261",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000265",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000326",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000327",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
-                "property": "RO:0002333",
-                "property-label": "enabled_by",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000300",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000306",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000252",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000291",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
-                "property": "RO:0002233",
-                "property-label": "has input",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000270",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000304",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000316",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000277",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000321",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000253",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000293",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000286",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000290",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000341",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000342",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000317",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000318",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000261",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000259",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000273",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000253",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000268",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000269",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
-                "property": "RO:0002333",
-                "property-label": "enabled_by",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000311",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000314",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000324",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000325",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000247",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000249",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000250",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000338",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000339",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
-                "property": "obo:GOREL_0002006",
-                "property-label": "results_in_organization_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000294",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000296",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000322",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000323",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000336",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000337",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000252",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000266",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000281",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000316",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000320",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
-                "property": "RO:0002333",
-                "property-label": "enabled_by",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000238",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000241",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
-                "property": "obo:GOREL_0002006",
-                "property-label": "results_in_organization_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000287",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000288",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000280",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000282",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000338",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000284",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000340",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000278",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000283",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236/56aac7ad00000253",
-                "property": "BFO:0000050",
-                "property-label": "part_of",
-                "object": "gomodel:56aac7ad00000236/56aac7ad00000247",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236/56aac7ad00000257",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            }
+  "packet-id": "109ff8e83e4de3",
+  "is-reasoned": false,
+  "intention": "query",
+  "signal": "rebuild",
+  "message-type": "success",
+  "message": "success",
+  "data": {
+    "modified-p": false,
+    "id": "gomodel:56aac7ad00000236",
+    "individuals": [
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000250",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
         ],
         "annotations": [
-            {
-                "key": "date",
-                "value": "2016-02-22"
-            },
-            {
-                "key": "contributor",
-                "value": "http://orcid.org/0000-0001-7476-6306"
-            },
-            {
-                "key": "state",
-                "value": "development"
-            },
-            {
-                "key": "title",
-                "value": "Mouse-Krt2-epidermis"
-            }
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
         ]
-    }
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000249",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0002415",
+            "label": "tail"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000247",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008544",
+            "label": "epidermis development"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "576"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "964"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000246",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000245",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96699",
+            "label": "Krt2 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000244",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008092",
+            "label": "cytoskeletal protein binding"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "285.25"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "16"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000241",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000343",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:3056582"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000342",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:3056582"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000238",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96699",
+            "label": "Krt2 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000340",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000297",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008092",
+            "label": "cytoskeletal protein binding"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "23.75"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "520.5"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000296",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000294",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045095",
+            "label": "keratin filament"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "579"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "363"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000293",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000291",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000290",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000339",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000338",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005198",
+            "label": "structural molecule activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "380"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "261"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000337",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000336",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000335",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000334",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000333",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000332",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000331",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000330",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000289",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000288",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000287",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045095",
+            "label": "keratin filament"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "211"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "46"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000286",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000285",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000284",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045109",
+            "label": "intermediate filament organization"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "432.75"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "515"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000283",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000282",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000281",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000280",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000341",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005198",
+            "label": "structural molecule activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "643"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "238"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000329",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000328",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000327",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000326",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000325",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000324",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000323",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000322",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000321",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:3056582"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000320",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:3056582"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000278",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000277",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045109",
+            "label": "intermediate filament organization"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "357"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000276",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000275",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000274",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000273",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000271",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96685",
+            "label": "Krt10 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000270",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96685",
+            "label": "Krt10 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000319",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000318",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000317",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005198",
+            "label": "structural molecule activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "215"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "300"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000316",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005198",
+            "label": "structural molecule activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "184"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "510"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000315",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000316",
+            "label": "genetic interaction evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:96699"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000314",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:3056582"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000312",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96699",
+            "label": "Krt2 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000311",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96685",
+            "label": "Krt10 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000269",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000270",
+            "label": "expression evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000268",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000266",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000265",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000263",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001691",
+            "label": "external ear"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000262",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008544",
+            "label": "epidermis development"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "173"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "947"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000261",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0003335",
+            "label": "corneocyte development"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "772"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000237",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008092",
+            "label": "cytoskeletal protein binding"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000308",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008092",
+            "label": "cytoskeletal protein binding"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "757.38330078125"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "220.5"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000307",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000316",
+            "label": "genetic interaction evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:96699"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000306",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:3056582"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000304",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000316",
+            "label": "genetic interaction evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:96685"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000303",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000316",
+            "label": "genetic interaction evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:96685"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000301",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96699",
+            "label": "Krt2 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000300",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96685",
+            "label": "Krt10 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000259",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0061436",
+            "label": "establishment of skin barrier"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "1005"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000257",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000253",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0003334",
+            "label": "keratinocyte development"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "708"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "548"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236/56aac7ad00000252",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0003334",
+            "label": "keratinocyte development"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "4"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "549"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      }
+    ],
+    "facts": [
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000301",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000307",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000334",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000335",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000285",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000289",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
+        "property": "RO:0002333",
+        "property-label": "enabled_by",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000245",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000246",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000328",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000329",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000317",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000277",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000319",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000271",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000303",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000341",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000284",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000343",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000261",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000262",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000274",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000312",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000315",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000262",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000263",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000276",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000330",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000331",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000252",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000262",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000275",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000332",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000333",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000252",
+        "property": "RO:0002411",
+        "property-label": "causally upstream of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000261",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000265",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000326",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000327",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
+        "property": "RO:0002333",
+        "property-label": "enabled_by",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000300",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000306",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000252",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000291",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000270",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000304",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000316",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000277",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000321",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000253",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000293",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000286",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000290",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000341",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000342",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000317",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000318",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000261",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000259",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000273",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000253",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000268",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000269",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
+        "property": "RO:0002333",
+        "property-label": "enabled_by",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000311",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000314",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000324",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000325",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000247",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000249",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000250",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000244",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000338",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000339",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000284",
+        "property": "obo:GOREL_0002006",
+        "property-label": "results_in_organization_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000294",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000296",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000322",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000323",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000297",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000336",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000337",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000252",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000266",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000281",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000308",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000316",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000320",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000237",
+        "property": "RO:0002333",
+        "property-label": "enabled_by",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000238",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000241",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
+        "property": "obo:GOREL_0002006",
+        "property-label": "results_in_organization_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000287",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000288",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000280",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000282",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000338",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000284",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000340",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000277",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000278",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000283",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236/56aac7ad00000253",
+        "property": "BFO:0000050",
+        "property-label": "part_of",
+        "object": "gomodel:56aac7ad00000236/56aac7ad00000247",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236/56aac7ad00000257",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      }
+    ],
+    "annotations": [
+      {
+        "key": "date",
+        "value": "2016-02-22"
+      },
+      {
+        "key": "contributor",
+        "value": "http://orcid.org/0000-0001-7476-6306"
+      },
+      {
+        "key": "state",
+        "value": "development"
+      },
+      {
+        "key": "title",
+        "value": "Mouse-Krt2-epidermis"
+      }
+    ]
+  }
 }

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-08.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-08.json
@@ -1,0 +1,3111 @@
+{
+    "packet-id": "8476ec06d62ec",
+    "uid": "GOC:kltm",
+    "is-reasoned": false,
+    "intention": "query",
+    "signal": "rebuild",
+    "message-type": "success",
+    "message": "success",
+    "data": {
+        "modified-p": false,
+        "id": "gomodel:56aac7ad00000236",
+        "individuals": [
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000056",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000055",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000054",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045095",
+                        "label": "keratin filament"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000071",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000249",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0002415",
+                        "label": "tail"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000247",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008544",
+                        "label": "epidermis development"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "611"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "821.0000305175781"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000246",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000245",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96699",
+                        "label": "Krt2 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008092",
+                        "label": "cytoskeletal protein binding"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "167.25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "15"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000340",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000241",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000238",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96699",
+                        "label": "Krt2 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008092",
+                        "label": "cytoskeletal protein binding"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "384.75"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "1074.88330078125"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000060",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045095",
+                        "label": "keratin filament"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000063",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000066",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045095",
+                        "label": "keratin filament"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000067",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000068",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045095",
+                        "label": "keratin filament"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000296",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000294",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045095",
+                        "label": "keratin filament"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "626.0000305175781"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "389"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000293",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000291",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000290",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000339",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000338",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005198",
+                        "label": "structural molecule activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "284"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "307"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000333",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000332",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000331",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000330",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000070",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045095",
+                        "label": "keratin filament"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000253",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003334",
+                        "label": "keratinocyte development"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "513.0000305175781"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "554"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000289",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000288",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000287",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045095",
+                        "label": "keratin filament"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "221"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "186"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000286",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000285",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045109",
+                        "label": "intermediate filament organization"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "199.75003051757812"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "471"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000283",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000282",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000281",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000280",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000329",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000328",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000327",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000326",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000325",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000324",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000252",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003334",
+                        "label": "keratinocyte development"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "841.0000305175781"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "53"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000322",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000321",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:3056582"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000320",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:3056582"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000278",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0045109",
+                        "label": "intermediate filament organization"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "544.5000305175781"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "214.25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000276",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000275",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000274",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000273",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000271",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96685",
+                        "label": "Krt10 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000270",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96685",
+                        "label": "Krt10 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000319",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000318",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005198",
+                        "label": "structural molecule activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "386"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "830.0000305175781"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005198",
+                        "label": "structural molecule activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "191"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "820.0000305175781"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000315",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000316",
+                        "label": "genetic interaction evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:96699"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000314",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:3056582"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000312",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96699",
+                        "label": "Krt2 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000311",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "MGI:MGI:96685",
+                        "label": "Krt10 Mmus"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000269",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000270",
+                        "label": "expression evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000268",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000266",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000265",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000069",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000263",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001691",
+                        "label": "external ear"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000262",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008544",
+                        "label": "epidermis development"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "548.0000305175781"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000261",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003335",
+                        "label": "corneocyte development"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "280"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "48.25"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000065",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000064",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000250",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000062",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CL:0000312",
+                        "label": "keratinocyte"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000061",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008092",
+                        "label": "cytoskeletal protein binding"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "1060.38330078125"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "7"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000304",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000316",
+                        "label": "genetic interaction evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "MGI:96685"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000303",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000316",
+                        "label": "genetic interaction evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:96685"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000323",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000259",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0061436",
+                        "label": "establishment of skin barrier"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "14"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56aac7ad00000257",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "with",
+                        "value": "MGI:4363845"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000059",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000058",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010402",
+                        "label": "epidermis suprabasal layer"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:56aac7ad00000236\/56d1143000000057",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:24751727"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    }
+                ]
+            }
+        ],
+        "facts": [
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000319",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56d1143000000060",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56d1143000000061",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000285",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000289",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+                "property": "RO:0002333",
+                "property-label": "enabled_by",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000245",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000246",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000328",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000329",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000324",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000325",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000262",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000263",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000276",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+                "property": "RO:0002233",
+                "property-label": "has input",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000271",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000303",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000261",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000262",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000274",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+                "property": "RO:0002333",
+                "property-label": "enabled_by",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000311",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000314",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000320",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000252",
+                "property": "RO:0002411",
+                "property-label": "causally upstream of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000261",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000265",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000318",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000252",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000262",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000275",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56d1143000000068",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56d1143000000069",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56d1143000000054",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56d1143000000055",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000326",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000327",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000252",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000291",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+                "property": "RO:0002233",
+                "property-label": "has input",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000270",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000304",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000321",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000286",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000290",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56d1143000000064",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56d1143000000065",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000278",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000283",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000261",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000259",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000273",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000253",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000268",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000269",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000330",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000331",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56d1143000000066",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56d1143000000067",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000253",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000293",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56d1143000000058",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56d1143000000059",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000338",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000339",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+                "property": "obo:GOREL_0002006",
+                "property-label": "results_in_organization_of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000294",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000296",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000322",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000323",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56d1143000000070",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56d1143000000071",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56d1143000000062",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56d1143000000063",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000252",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000266",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000281",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000247",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000249",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000250",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000253",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000247",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000257",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56d1143000000056",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56d1143000000057",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-03-02"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+                "property": "obo:GOREL_0002006",
+                "property-label": "results_in_organization_of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000287",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000288",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000280",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000282",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000338",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000340",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000332",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000333",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+                "property": "RO:0002233",
+                "property-label": "has input",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000312",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000315",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-22"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+                "property": "RO:0002333",
+                "property-label": "enabled_by",
+                "object": "gomodel:56aac7ad00000236\/56aac7ad00000238",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000241",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-02-19"
+                    }
+                ]
+            }
+        ],
+        "annotations": [
+            {
+                "key": "contributor",
+                "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+            },
+            {
+                "key": "state",
+                "value": "development"
+            },
+            {
+                "key": "date",
+                "value": "2016-03-02"
+            },
+            {
+                "key": "title",
+                "value": "Mouse-Krt2-epidermis"
+            }
+        ]
+    }
+}

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-08.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-08.json
@@ -1,3111 +1,3111 @@
 {
-    "packet-id": "8476ec06d62ec",
-    "uid": "GOC:kltm",
-    "is-reasoned": false,
-    "intention": "query",
-    "signal": "rebuild",
-    "message-type": "success",
-    "message": "success",
-    "data": {
-        "modified-p": false,
-        "id": "gomodel:56aac7ad00000236",
-        "individuals": [
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000056",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000055",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000054",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045095",
-                        "label": "keratin filament"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000071",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000249",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0002415",
-                        "label": "tail"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000247",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008544",
-                        "label": "epidermis development"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "611"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "821.0000305175781"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000246",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000245",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96699",
-                        "label": "Krt2 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000244",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008092",
-                        "label": "cytoskeletal protein binding"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "167.25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "15"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000340",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000241",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000238",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96699",
-                        "label": "Krt2 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000237",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008092",
-                        "label": "cytoskeletal protein binding"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "384.75"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "1074.88330078125"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000060",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045095",
-                        "label": "keratin filament"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000063",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000066",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045095",
-                        "label": "keratin filament"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000067",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000068",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045095",
-                        "label": "keratin filament"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000296",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000294",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045095",
-                        "label": "keratin filament"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "626.0000305175781"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "389"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000293",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000291",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000290",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000339",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000338",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005198",
-                        "label": "structural molecule activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "284"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "307"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000333",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000332",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000331",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000330",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000070",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045095",
-                        "label": "keratin filament"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000253",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003334",
-                        "label": "keratinocyte development"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "513.0000305175781"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "554"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000289",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000288",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000287",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045095",
-                        "label": "keratin filament"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "221"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "186"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000286",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000285",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000284",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045109",
-                        "label": "intermediate filament organization"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "199.75003051757812"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "471"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000283",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000282",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000281",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000280",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000329",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000328",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000327",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000326",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000325",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000324",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000252",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003334",
-                        "label": "keratinocyte development"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "841.0000305175781"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "53"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000322",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000321",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:3056582"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000320",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:3056582"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000278",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000277",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0045109",
-                        "label": "intermediate filament organization"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "544.5000305175781"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "214.25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000276",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000275",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000274",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000273",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000271",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96685",
-                        "label": "Krt10 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000270",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96685",
-                        "label": "Krt10 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000319",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000318",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000317",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005198",
-                        "label": "structural molecule activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "386"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "830.0000305175781"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000316",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005198",
-                        "label": "structural molecule activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "191"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "820.0000305175781"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000315",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000316",
-                        "label": "genetic interaction evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:96699"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000314",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:3056582"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000312",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96699",
-                        "label": "Krt2 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000311",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "MGI:MGI:96685",
-                        "label": "Krt10 Mmus"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000269",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000270",
-                        "label": "expression evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000268",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000266",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000265",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000069",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000263",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001691",
-                        "label": "external ear"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000262",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008544",
-                        "label": "epidermis development"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "548.0000305175781"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000261",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003335",
-                        "label": "corneocyte development"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "280"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "48.25"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000065",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000064",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000250",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000062",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CL:0000312",
-                        "label": "keratinocyte"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000061",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000308",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008092",
-                        "label": "cytoskeletal protein binding"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "1060.38330078125"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "7"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000304",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000316",
-                        "label": "genetic interaction evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "MGI:96685"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000303",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000316",
-                        "label": "genetic interaction evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:96685"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000323",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000259",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0061436",
-                        "label": "establishment of skin barrier"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "14"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56aac7ad00000257",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "with",
-                        "value": "MGI:4363845"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000059",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000058",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010402",
-                        "label": "epidermis suprabasal layer"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:56aac7ad00000236\/56d1143000000057",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:24751727"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    }
-                ]
-            }
-        ],
-        "facts": [
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000277",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000319",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56d1143000000060",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56d1143000000061",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000285",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000289",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
-                "property": "RO:0002333",
-                "property-label": "enabled_by",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000245",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000246",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000328",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000329",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000324",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000325",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000262",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000263",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000276",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
-                "property": "RO:0002233",
-                "property-label": "has input",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000271",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000303",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000261",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000262",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000274",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
-                "property": "RO:0002333",
-                "property-label": "enabled_by",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000311",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000314",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000316",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000320",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000252",
-                "property": "RO:0002411",
-                "property-label": "causally upstream of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000261",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000265",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000317",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000318",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000252",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000262",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000275",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56d1143000000068",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56d1143000000069",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56d1143000000054",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56d1143000000055",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000326",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000327",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000252",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000291",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
-                "property": "RO:0002233",
-                "property-label": "has input",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000270",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000304",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000277",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000321",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000286",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000290",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56d1143000000064",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56d1143000000065",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000278",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000283",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000261",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000259",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000273",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000253",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000268",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000269",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000330",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000331",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56d1143000000066",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56d1143000000067",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000253",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000293",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56d1143000000058",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56d1143000000059",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000338",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000339",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
-                "property": "obo:GOREL_0002006",
-                "property-label": "results_in_organization_of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000294",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000296",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000322",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000323",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56d1143000000070",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56d1143000000071",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56d1143000000062",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56d1143000000063",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000252",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000266",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000281",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000247",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000249",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000250",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000253",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000247",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000257",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56d1143000000056",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56d1143000000057",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-03-02"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
-                "property": "obo:GOREL_0002006",
-                "property-label": "results_in_organization_of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000287",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000288",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000280",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000282",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000338",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000284",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000340",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000332",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000333",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
-                "property": "RO:0002233",
-                "property-label": "has input",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000312",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000315",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-22"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
-                "property": "RO:0002333",
-                "property-label": "enabled_by",
-                "object": "gomodel:56aac7ad00000236\/56aac7ad00000238",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:56aac7ad00000236\/56aac7ad00000241",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-02-19"
-                    }
-                ]
-            }
+  "packet-id": "8476ec06d62ec",
+  "uid": "GOC:kltm",
+  "is-reasoned": false,
+  "intention": "query",
+  "signal": "rebuild",
+  "message-type": "success",
+  "message": "success",
+  "data": {
+    "modified-p": false,
+    "id": "gomodel:56aac7ad00000236",
+    "individuals": [
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000056",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
         ],
         "annotations": [
-            {
-                "key": "contributor",
-                "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
-            },
-            {
-                "key": "state",
-                "value": "development"
-            },
-            {
-                "key": "date",
-                "value": "2016-03-02"
-            },
-            {
-                "key": "title",
-                "value": "Mouse-Krt2-epidermis"
-            }
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
         ]
-    }
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000055",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000054",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045095",
+            "label": "keratin filament"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000071",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000249",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0002415",
+            "label": "tail"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000247",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008544",
+            "label": "epidermis development"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "611"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "821.0000305175781"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000246",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000245",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96699",
+            "label": "Krt2 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008092",
+            "label": "cytoskeletal protein binding"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "167.25"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "15"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000340",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000241",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000238",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96699",
+            "label": "Krt2 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008092",
+            "label": "cytoskeletal protein binding"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "384.75"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "1074.88330078125"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000060",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045095",
+            "label": "keratin filament"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000063",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000066",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045095",
+            "label": "keratin filament"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000067",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000068",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045095",
+            "label": "keratin filament"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000296",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000294",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045095",
+            "label": "keratin filament"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "626.0000305175781"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "389"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000293",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000291",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000290",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000339",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000338",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005198",
+            "label": "structural molecule activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "284"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "307"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000333",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000332",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000331",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000330",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000070",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045095",
+            "label": "keratin filament"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000253",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0003334",
+            "label": "keratinocyte development"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "513.0000305175781"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "554"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000289",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000288",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000287",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045095",
+            "label": "keratin filament"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "221"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "186"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000286",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000285",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045109",
+            "label": "intermediate filament organization"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "199.75003051757812"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "471"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000283",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000282",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000281",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000280",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000329",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000328",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000327",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000326",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000325",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000324",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000252",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0003334",
+            "label": "keratinocyte development"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "841.0000305175781"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "53"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000322",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000321",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:3056582"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000320",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:3056582"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000278",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0045109",
+            "label": "intermediate filament organization"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "544.5000305175781"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "214.25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000276",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000275",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000274",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000273",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000271",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96685",
+            "label": "Krt10 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000270",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96685",
+            "label": "Krt10 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000319",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000318",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005198",
+            "label": "structural molecule activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "386"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "830.0000305175781"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005198",
+            "label": "structural molecule activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "191"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "820.0000305175781"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000315",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000316",
+            "label": "genetic interaction evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "with",
+            "value": "MGI:96699"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000314",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:3056582"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000312",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96699",
+            "label": "Krt2 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000311",
+        "type": [
+          {
+            "type": "class",
+            "id": "MGI:MGI:96685",
+            "label": "Krt10 Mmus"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000269",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000270",
+            "label": "expression evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000268",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000266",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000265",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000069",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000263",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001691",
+            "label": "external ear"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000262",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008544",
+            "label": "epidermis development"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "548.0000305175781"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000261",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0003335",
+            "label": "corneocyte development"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "280"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "48.25"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000065",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000064",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000250",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000062",
+        "type": [
+          {
+            "type": "class",
+            "id": "CL:0000312",
+            "label": "keratinocyte"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000061",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008092",
+            "label": "cytoskeletal protein binding"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "1060.38330078125"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "7"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000304",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000316",
+            "label": "genetic interaction evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "MGI:96685"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000303",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000316",
+            "label": "genetic interaction evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "with",
+            "value": "MGI:96685"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000323",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000259",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0061436",
+            "label": "establishment of skin barrier"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "14"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56aac7ad00000257",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "with",
+            "value": "MGI:4363845"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000059",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000058",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010402",
+            "label": "epidermis suprabasal layer"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:56aac7ad00000236\/56d1143000000057",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:24751727"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          }
+        ]
+      }
+    ],
+    "facts": [
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000319",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56d1143000000060",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56d1143000000061",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000285",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000289",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+        "property": "RO:0002333",
+        "property-label": "enabled_by",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000245",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000246",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000328",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000329",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000324",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000325",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000262",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000263",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000276",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000271",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000303",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000261",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000262",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000274",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+        "property": "RO:0002333",
+        "property-label": "enabled_by",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000311",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000314",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000320",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000252",
+        "property": "RO:0002411",
+        "property-label": "causally upstream of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000261",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000265",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000318",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000252",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000262",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000275",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56d1143000000068",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56d1143000000069",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56d1143000000054",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56d1143000000055",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000326",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000327",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000252",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000291",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000270",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000304",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000321",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000286",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000290",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56d1143000000064",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56d1143000000065",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000278",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000283",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000261",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000259",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000273",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000253",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000268",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000269",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000330",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000331",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56d1143000000066",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56d1143000000067",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000253",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000293",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56d1143000000058",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56d1143000000059",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000338",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000339",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+        "property": "obo:GOREL_0002006",
+        "property-label": "results_in_organization_of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000294",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000296",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000322",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000323",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56d1143000000070",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56d1143000000071",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000317",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56d1143000000062",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56d1143000000063",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000252",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000266",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000281",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000247",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000249",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000250",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000253",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000247",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000257",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000316",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56d1143000000056",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56d1143000000057",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-03-02"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+        "property": "obo:GOREL_0002006",
+        "property-label": "results_in_organization_of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000287",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000288",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000277",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000280",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000282",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000338",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000284",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000340",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000244",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000332",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000333",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000308",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000312",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000315",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-22"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:56aac7ad00000236\/56aac7ad00000237",
+        "property": "RO:0002333",
+        "property-label": "enabled_by",
+        "object": "gomodel:56aac7ad00000236\/56aac7ad00000238",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:56aac7ad00000236\/56aac7ad00000241",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+          },
+          {
+            "key": "date",
+            "value": "2016-02-19"
+          }
+        ]
+      }
+    ],
+    "annotations": [
+      {
+        "key": "contributor",
+        "value": "http:\/\/orcid.org\/0000-0001-7476-6306"
+      },
+      {
+        "key": "state",
+        "value": "development"
+      },
+      {
+        "key": "date",
+        "value": "2016-03-02"
+      },
+      {
+        "key": "title",
+        "value": "Mouse-Krt2-epidermis"
+      }
+    ]
+  }
 }

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-09.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-09.json
@@ -1,0 +1,403 @@
+{
+    "packet-id": "f60f7885802a3b",
+    "uid": "GOC:kltm",
+    "is-reasoned": false,
+    "intention": "query",
+    "signal": "rebuild",
+    "message-type": "success",
+    "message": "success",
+    "data": {
+        "modified-p": false,
+        "id": "gomodel:5798651000000002",
+        "individuals": [
+            {
+                "id": "gomodel:5798651000000002/5798651000000009",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001833",
+                        "label": "lip"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "318"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "493.5"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5798651000000002/5798651000000008",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001723",
+                        "label": "tongue"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "423"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "249.25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5798651000000002/5798651000000006",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "PATO:0002258",
+                        "label": "pointed"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "151"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "379"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5798651000000002/5798651000000005",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0000165",
+                        "label": "mouth"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "320"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "55"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5798651000000002/5798651000000004",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "PATO:0001419",
+                        "label": "sharp"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "377"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "56"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5798651000000002/5798651000000003",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0009680",
+                        "label": "set of upper jaw teeth"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "106"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "76"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5798651000000002/5798651000000010",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0010879",
+                        "label": "tusk"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "496"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "237"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5798651000000002/5798651000000033",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001727",
+                        "label": "taste bud"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "429"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "562"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    }
+                ]
+            }
+        ],
+        "facts": [
+            {
+                "subject": "gomodel:5798651000000002/5798651000000005",
+                "property": "BFO:0000051",
+                "property-label": "has_part",
+                "object": "gomodel:5798651000000002/5798651000000010",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5798651000000002/5798651000000008",
+                "property": "BFO:0000051",
+                "property-label": "has_part",
+                "object": "gomodel:5798651000000002/5798651000000033",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:kltm"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5798651000000002/5798651000000005",
+                "property": "BFO:0000051",
+                "property-label": "has_part",
+                "object": "gomodel:5798651000000002/5798651000000008",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5798651000000002/5798651000000003",
+                "property": "RO:0000053",
+                "property-label": "bearer of",
+                "object": "gomodel:5798651000000002/5798651000000004",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5798651000000002/5798651000000005",
+                "property": "BFO:0000051",
+                "property-label": "has_part",
+                "object": "gomodel:5798651000000002/5798651000000009",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5798651000000002/5798651000000003",
+                "property": "RO:0000053",
+                "property-label": "bearer of",
+                "object": "gomodel:5798651000000002/5798651000000006",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5798651000000002/5798651000000005",
+                "property": "BFO:0000051",
+                "property-label": "has_part",
+                "object": "gomodel:5798651000000002/5798651000000003",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-6601-2165"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2016-07-29"
+                    }
+                ]
+            }
+        ],
+        "annotations": [
+            {
+                "key": "state",
+                "value": "development"
+            },
+            {
+                "key": "title",
+                "value": "rabbit with sharp teeth"
+            },
+            {
+                "key": "contributor",
+                "value": "http://orcid.org/0000-0002-6601-2165"
+            },
+            {
+                "key": "date",
+                "value": "2016-07-29"
+            },
+            {
+                "key": "contributor",
+                "value": "GOC:kltm"
+            }
+        ]
+    }
+}

--- a/packages/bbop-graph-noctua/src/fixtures/minerva-09.json
+++ b/packages/bbop-graph-noctua/src/fixtures/minerva-09.json
@@ -1,403 +1,403 @@
 {
-    "packet-id": "f60f7885802a3b",
-    "uid": "GOC:kltm",
-    "is-reasoned": false,
-    "intention": "query",
-    "signal": "rebuild",
-    "message-type": "success",
-    "message": "success",
-    "data": {
-        "modified-p": false,
-        "id": "gomodel:5798651000000002",
-        "individuals": [
-            {
-                "id": "gomodel:5798651000000002/5798651000000009",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001833",
-                        "label": "lip"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "318"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "493.5"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5798651000000002/5798651000000008",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001723",
-                        "label": "tongue"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "423"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "249.25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5798651000000002/5798651000000006",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "PATO:0002258",
-                        "label": "pointed"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "151"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "379"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5798651000000002/5798651000000005",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0000165",
-                        "label": "mouth"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "320"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "55"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5798651000000002/5798651000000004",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "PATO:0001419",
-                        "label": "sharp"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "377"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "56"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5798651000000002/5798651000000003",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0009680",
-                        "label": "set of upper jaw teeth"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "106"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "76"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5798651000000002/5798651000000010",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0010879",
-                        "label": "tusk"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "496"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "237"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5798651000000002/5798651000000033",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001727",
-                        "label": "taste bud"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "429"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "562"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    }
-                ]
-            }
-        ],
-        "facts": [
-            {
-                "subject": "gomodel:5798651000000002/5798651000000005",
-                "property": "BFO:0000051",
-                "property-label": "has_part",
-                "object": "gomodel:5798651000000002/5798651000000010",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5798651000000002/5798651000000008",
-                "property": "BFO:0000051",
-                "property-label": "has_part",
-                "object": "gomodel:5798651000000002/5798651000000033",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:kltm"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5798651000000002/5798651000000005",
-                "property": "BFO:0000051",
-                "property-label": "has_part",
-                "object": "gomodel:5798651000000002/5798651000000008",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5798651000000002/5798651000000003",
-                "property": "RO:0000053",
-                "property-label": "bearer of",
-                "object": "gomodel:5798651000000002/5798651000000004",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5798651000000002/5798651000000005",
-                "property": "BFO:0000051",
-                "property-label": "has_part",
-                "object": "gomodel:5798651000000002/5798651000000009",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5798651000000002/5798651000000003",
-                "property": "RO:0000053",
-                "property-label": "bearer of",
-                "object": "gomodel:5798651000000002/5798651000000006",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5798651000000002/5798651000000005",
-                "property": "BFO:0000051",
-                "property-label": "has_part",
-                "object": "gomodel:5798651000000002/5798651000000003",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-6601-2165"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2016-07-29"
-                    }
-                ]
-            }
+  "packet-id": "f60f7885802a3b",
+  "uid": "GOC:kltm",
+  "is-reasoned": false,
+  "intention": "query",
+  "signal": "rebuild",
+  "message-type": "success",
+  "message": "success",
+  "data": {
+    "modified-p": false,
+    "id": "gomodel:5798651000000002",
+    "individuals": [
+      {
+        "id": "gomodel:5798651000000002/5798651000000009",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001833",
+            "label": "lip"
+          }
         ],
         "annotations": [
-            {
-                "key": "state",
-                "value": "development"
-            },
-            {
-                "key": "title",
-                "value": "rabbit with sharp teeth"
-            },
-            {
-                "key": "contributor",
-                "value": "http://orcid.org/0000-0002-6601-2165"
-            },
-            {
-                "key": "date",
-                "value": "2016-07-29"
-            },
-            {
-                "key": "contributor",
-                "value": "GOC:kltm"
-            }
+          {
+            "key": "hint-layout-y",
+            "value": "318"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "493.5"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          }
         ]
-    }
+      },
+      {
+        "id": "gomodel:5798651000000002/5798651000000008",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001723",
+            "label": "tongue"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "423"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "249.25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5798651000000002/5798651000000006",
+        "type": [
+          {
+            "type": "class",
+            "id": "PATO:0002258",
+            "label": "pointed"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "151"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "379"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5798651000000002/5798651000000005",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0000165",
+            "label": "mouth"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "320"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "55"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5798651000000002/5798651000000004",
+        "type": [
+          {
+            "type": "class",
+            "id": "PATO:0001419",
+            "label": "sharp"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "377"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "56"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5798651000000002/5798651000000003",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0009680",
+            "label": "set of upper jaw teeth"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "106"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "76"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5798651000000002/5798651000000010",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0010879",
+            "label": "tusk"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "496"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "237"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5798651000000002/5798651000000033",
+        "type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001727",
+            "label": "taste bud"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "429"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "562"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          }
+        ]
+      }
+    ],
+    "facts": [
+      {
+        "subject": "gomodel:5798651000000002/5798651000000005",
+        "property": "BFO:0000051",
+        "property-label": "has_part",
+        "object": "gomodel:5798651000000002/5798651000000010",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5798651000000002/5798651000000008",
+        "property": "BFO:0000051",
+        "property-label": "has_part",
+        "object": "gomodel:5798651000000002/5798651000000033",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:kltm"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5798651000000002/5798651000000005",
+        "property": "BFO:0000051",
+        "property-label": "has_part",
+        "object": "gomodel:5798651000000002/5798651000000008",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5798651000000002/5798651000000003",
+        "property": "RO:0000053",
+        "property-label": "bearer of",
+        "object": "gomodel:5798651000000002/5798651000000004",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5798651000000002/5798651000000005",
+        "property": "BFO:0000051",
+        "property-label": "has_part",
+        "object": "gomodel:5798651000000002/5798651000000009",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5798651000000002/5798651000000003",
+        "property": "RO:0000053",
+        "property-label": "bearer of",
+        "object": "gomodel:5798651000000002/5798651000000006",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5798651000000002/5798651000000005",
+        "property": "BFO:0000051",
+        "property-label": "has_part",
+        "object": "gomodel:5798651000000002/5798651000000003",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-6601-2165"
+          },
+          {
+            "key": "date",
+            "value": "2016-07-29"
+          }
+        ]
+      }
+    ],
+    "annotations": [
+      {
+        "key": "state",
+        "value": "development"
+      },
+      {
+        "key": "title",
+        "value": "rabbit with sharp teeth"
+      },
+      {
+        "key": "contributor",
+        "value": "http://orcid.org/0000-0002-6601-2165"
+      },
+      {
+        "key": "date",
+        "value": "2016-07-29"
+      },
+      {
+        "key": "contributor",
+        "value": "GOC:kltm"
+      }
+    ]
+  }
 }

--- a/packages/bbop-graph-noctua/src/fixtures/response-gomodel-596ef51500000088-2020-07-01.json
+++ b/packages/bbop-graph-noctua/src/fixtures/response-gomodel-596ef51500000088-2020-07-01.json
@@ -1,0 +1,3120 @@
+{
+    "packet-id": "57b88f654855a12e",
+    "provided-by": [],
+    "is-reasoned": false,
+    "intention": "query",
+    "signal": "rebuild",
+    "message-type": "success",
+    "message": "success",
+    "data": {
+        "modified-p": false,
+        "id": "gomodel:596ef51500000088",
+        "individuals": [
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000465",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:P35222",
+                        "label": "CTNNB1 Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000466",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:P35222",
+                        "label": "CTNNB1 Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000467",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:O15169",
+                        "label": "AXIN1 Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000469",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000353",
+                        "label": "physical interaction evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "UniProtKB:O70239"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:10330181"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000470",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:11955436"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000471",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:11955436"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000472",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:9065402"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000475",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0090090",
+                        "label": "negative regulation of canonical Wnt signaling pathway"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008150",
+                        "label": "Biological Process"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "287"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "896.625"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000477",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:11955436"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-01"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000478",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-01"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:10644691"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000479",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2018-10-01"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:22899650"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000505",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:11029007"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000514",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005886",
+                        "label": "plasma membrane"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001062",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0110165",
+                        "label": "cellular anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "Cellular Component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5b91dbd100000515",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000318",
+                        "label": "biological aspect of ancestor evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "with",
+                        "value": "PANTHER:PTN000139394"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "source",
+                        "value": "GO_REF:0000033"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000111",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0015026",
+                        "label": "coreceptor activity"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "215"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "305"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-7073-9172"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000112",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:O75581",
+                        "label": "LRP6 Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "468.75"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000113",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-19"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:11029007"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000117",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0030159",
+                        "label": "signaling receptor complex adaptor activity"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "491"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "136"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000118",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:O14640",
+                        "label": "DVL1 Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "3225"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000119",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000353",
+                        "label": "physical interaction evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "with",
+                        "value": "UniProtKB:O70239"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-19"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:10330181"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000128",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003713",
+                        "label": "transcription coactivator activity"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "553"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "1222"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000142",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005829",
+                        "label": "cytosol"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001062",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0110165",
+                        "label": "cellular anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "Cellular Component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "2831.25"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000143",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000318",
+                        "label": "biological aspect of ancestor evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "GO_REF:0000033"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "with",
+                        "value": "PANTHER:PTN000093945"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-19"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000144",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005634",
+                        "label": "nucleus"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001062",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0110165",
+                        "label": "cellular anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "Cellular Component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "7162.5"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000145",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:10980594"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-19"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000146",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005886",
+                        "label": "plasma membrane"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001062",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0110165",
+                        "label": "cellular anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "Cellular Component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "862.5"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000147",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:16263759"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-19"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000166",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0030877",
+                        "label": "beta-catenin destruction complex"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "Cellular Component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0032991",
+                        "label": "protein-containing complex"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "263"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "672"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000167",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:O15169",
+                        "label": "AXIN1 Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "639"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "481"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000168",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:P25054",
+                        "label": "APC Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "1650"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000169",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:P49841",
+                        "label": "GSK3B Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "1256.25"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000170",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:P48729",
+                        "label": "CSNK1A1 Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "2043.75"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000171",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:11955436"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-19"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000172",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:16188939"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-19"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000173",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2017-07-19"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:16188939"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000174",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2017-07-19"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:16188939"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000175",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0004674",
+                        "label": "protein serine/threonine kinase activity"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "511"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "570"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000178",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:11955436"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-19"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000180",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005829",
+                        "label": "cytosol"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001062",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0110165",
+                        "label": "cellular anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "Cellular Component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "5587.5"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000181",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-19"
+                    },
+                    {
+                        "key": "source",
+                        "value": "GO_REF:0000052"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000182",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:1901800",
+                        "label": "positive regulation of proteasomal protein catabolic process"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008150",
+                        "label": "Biological Process"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "483"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "891"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000183",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:P35222",
+                        "label": "CTNNB1 Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "163"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "1398"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/596ef51500000184",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0060070",
+                        "label": "canonical Wnt signaling pathway"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0008150",
+                        "label": "Biological Process"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "949"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "45"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000217",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0048018",
+                        "label": "receptor ligand activity"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "10"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000220",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0042813",
+                        "label": "Wnt-activated receptor activity"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2018-10-01"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "234"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "7"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000221",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:Q9UP38",
+                        "label": "FZD1 Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "6768.75"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000222",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000303",
+                        "label": "author statement without traceable support used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:23461676"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-24"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000232",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:Q9UP38",
+                        "label": "FZD1 Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "4800"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000236",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000353",
+                        "label": "physical interaction evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:10557084"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-24"
+                    },
+                    {
+                        "key": "with",
+                        "value": "UniProtKB:Q9UP38"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000239",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000094",
+                        "label": "biological assay evidence"
+                    }
+                ],
+                "root-type": [],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:10557084"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-24"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000241",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000094",
+                        "label": "biological assay evidence"
+                    }
+                ],
+                "root-type": [],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2017-07-24"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:14739301"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000243",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000094",
+                        "label": "biological assay evidence"
+                    }
+                ],
+                "root-type": [],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-24"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:11113207"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000244",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000094",
+                        "label": "biological assay evidence"
+                    }
+                ],
+                "root-type": [],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-24"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:10644691"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000246",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000015",
+                        "label": "mutant phenotype evidence"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:11955436"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-24"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000248",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000353",
+                        "label": "physical interaction evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:10557084"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-25"
+                    },
+                    {
+                        "key": "with",
+                        "value": "UniProtKB:Q9UP38"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000250",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000353",
+                        "label": "physical interaction evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "with",
+                        "value": "UniProtKB:O70239"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-25"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:10330181"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000678",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005615",
+                        "label": "extracellular space"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001062",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0110165",
+                        "label": "cellular anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "Cellular Component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "hint-layout-x",
+                        "value": "4012.5"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5970219a00000679",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000318",
+                        "label": "biological aspect of ancestor evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "GO_REF:0000033"
+                    },
+                    {
+                        "key": "with",
+                        "value": "PANTHER:PTN000246517"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-07-31"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5993df9e00000344",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "UniProtKB:P56703",
+                        "label": "WNT3 Hsap"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi information biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36080",
+                        "label": "chebi protein"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "hint-layout-x",
+                        "value": "4406.25"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-24"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "hint-layout-y",
+                        "value": "75"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:596ef51500000088/5993df9e00000345",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000353",
+                        "label": "physical interaction evidence used in manual assertion"
+                    }
+                ],
+                "root-type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:10557084"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-08-22"
+                    },
+                    {
+                        "key": "with",
+                        "value": "UniProtKB:Q9UP38"
+                    }
+                ]
+            }
+        ],
+        "facts": [
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000175",
+                "property": "RO:0002233",
+                "property-label": "has input",
+                "object": "gomodel:596ef51500000088/5b91dbd100000465",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5b91dbd100000470",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000128",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:596ef51500000088/596ef51500000184",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5970219a00000244",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000111",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:596ef51500000088/596ef51500000146",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/596ef51500000147",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/5970219a00000217",
+                "property": "RO:0002233",
+                "property-label": "has input",
+                "object": "gomodel:596ef51500000088/5970219a00000232",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5970219a00000248",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/5970219a00000217",
+                "property": "RO:0002629",
+                "property-label": "directly positively regulates",
+                "object": "gomodel:596ef51500000088/596ef51500000111",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-01"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000117",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:596ef51500000088/596ef51500000142",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/596ef51500000143",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000166",
+                "property": "BFO:0000051",
+                "property-label": "has part",
+                "object": "gomodel:596ef51500000088/596ef51500000167",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/596ef51500000173",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000111",
+                "property": "RO:0002629",
+                "property-label": "directly positively regulates",
+                "object": "gomodel:596ef51500000088/596ef51500000117",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-01"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/5970219a00000217",
+                "property": "RO:0002629",
+                "property-label": "directly positively regulates",
+                "object": "gomodel:596ef51500000088/5970219a00000220",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5970219a00000236",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000175",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:596ef51500000088/596ef51500000180",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/596ef51500000181",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/5970219a00000220",
+                "property": "RO:0002629",
+                "property-label": "directly positively regulates",
+                "object": "gomodel:596ef51500000088/596ef51500000117",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "GOC:pt"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2017-09-11"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000117",
+                "property": "RO:0002233",
+                "property-label": "has input",
+                "object": "gomodel:596ef51500000088/5b91dbd100000467",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5b91dbd100000469",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000182",
+                "property": "RO:0002233",
+                "property-label": "has input",
+                "object": "gomodel:596ef51500000088/5b91dbd100000466",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5b91dbd100000471",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000182",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:596ef51500000088/5b91dbd100000475",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5b91dbd100000478",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5b91dbd100000479",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-01"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000111",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:596ef51500000088/596ef51500000112",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/596ef51500000113",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000117",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:596ef51500000088/596ef51500000118",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/596ef51500000119",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000111",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:596ef51500000088/596ef51500000184",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5b91dbd100000505",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/5970219a00000220",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:596ef51500000088/596ef51500000184",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5970219a00000241",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000128",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:596ef51500000088/596ef51500000183",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5b91dbd100000472",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-09-30"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000166",
+                "property": "BFO:0000051",
+                "property-label": "has part",
+                "object": "gomodel:596ef51500000088/596ef51500000170",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/596ef51500000171",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/5970219a00000217",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:596ef51500000088/596ef51500000184",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5970219a00000239",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/5970219a00000220",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:596ef51500000088/5970219a00000221",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5970219a00000222",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000182",
+                "property": "RO:0002212",
+                "property-label": "negatively regulates",
+                "object": "gomodel:596ef51500000088/596ef51500000128",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5970219a00000246",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/5970219a00000217",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:596ef51500000088/5970219a00000678",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5970219a00000679",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000166",
+                "property": "BFO:0000051",
+                "property-label": "has part",
+                "object": "gomodel:596ef51500000088/596ef51500000168",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/596ef51500000174",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000128",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:596ef51500000088/596ef51500000144",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/596ef51500000145",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000166",
+                "property": "BFO:0000051",
+                "property-label": "has part",
+                "object": "gomodel:596ef51500000088/596ef51500000169",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/596ef51500000172",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000117",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:596ef51500000088/596ef51500000184",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5970219a00000243",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000175",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:596ef51500000088/596ef51500000182",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5b91dbd100000477",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-9074-3507"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-01"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://geneontology.org"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/5970219a00000220",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:596ef51500000088/5b91dbd100000514",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5b91dbd100000515",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2018-10-02"
+                    },
+                    {
+                        "key": "providedBy",
+                        "value": "http://www.wormbase.org"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000175",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:596ef51500000088/596ef51500000166",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/596ef51500000178",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/596ef51500000117",
+                "property": "RO:0002630",
+                "property-label": "directly negatively regulates",
+                "object": "gomodel:596ef51500000088/596ef51500000175",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5970219a00000250",
+                        "value-type": "IRI"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:596ef51500000088/5970219a00000217",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:596ef51500000088/5993df9e00000344",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:596ef51500000088/5993df9e00000345",
+                        "value-type": "IRI"
+                    }
+                ]
+            }
+        ],
+        "annotations": [
+            {
+                "key": "state",
+                "value": "development"
+            },
+            {
+                "key": "contributor",
+                "value": "GOC:pt"
+            },
+            {
+                "key": "contributor",
+                "value": "http://orcid.org/0000-0002-1706-4196"
+            },
+            {
+                "key": "contributor",
+                "value": "http://orcid.org/0000-0002-7073-9172"
+            },
+            {
+                "key": "contributor",
+                "value": "http://orcid.org/0000-0002-9074-3507"
+            },
+            {
+                "key": "date",
+                "value": "2018-10-02"
+            },
+            {
+                "key": "title",
+                "value": "canonical wnt using companions"
+            },
+            {
+                "key": "providedBy",
+                "value": "http://geneontology.org"
+            },
+            {
+                "key": "providedBy",
+                "value": "http://www.wormbase.org"
+            },
+            {
+                "key": "http://www.geneontology.org/formats/oboInOwl#id",
+                "value": "gomodel:596ef51500000088"
+            },
+            {
+                "key": "https://w3id.org/biolink/vocab/in_taxon",
+                "value": "NCBITaxon:9606",
+                "value-type": "IRI"
+            }
+        ]
+    }
+}

--- a/packages/bbop-graph-noctua/src/fixtures/response-gomodel-596ef51500000088-2020-07-01.json
+++ b/packages/bbop-graph-noctua/src/fixtures/response-gomodel-596ef51500000088-2020-07-01.json
@@ -1,3120 +1,3120 @@
 {
-    "packet-id": "57b88f654855a12e",
-    "provided-by": [],
-    "is-reasoned": false,
-    "intention": "query",
-    "signal": "rebuild",
-    "message-type": "success",
-    "message": "success",
-    "data": {
-        "modified-p": false,
-        "id": "gomodel:596ef51500000088",
-        "individuals": [
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000465",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:P35222",
-                        "label": "CTNNB1 Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000466",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:P35222",
-                        "label": "CTNNB1 Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000467",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:O15169",
-                        "label": "AXIN1 Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000469",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000353",
-                        "label": "physical interaction evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "UniProtKB:O70239"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:10330181"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000470",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:11955436"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000471",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:11955436"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000472",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:9065402"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000475",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0090090",
-                        "label": "negative regulation of canonical Wnt signaling pathway"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008150",
-                        "label": "Biological Process"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "287"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "896.625"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000477",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:11955436"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-01"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000478",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-01"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:10644691"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000479",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2018-10-01"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:22899650"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000505",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:11029007"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000514",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005886",
-                        "label": "plasma membrane"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001062",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0110165",
-                        "label": "cellular anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "Cellular Component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5b91dbd100000515",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000318",
-                        "label": "biological aspect of ancestor evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "with",
-                        "value": "PANTHER:PTN000139394"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "source",
-                        "value": "GO_REF:0000033"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000111",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0015026",
-                        "label": "coreceptor activity"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "215"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "305"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-7073-9172"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000112",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:O75581",
-                        "label": "LRP6 Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "468.75"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000113",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-19"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:11029007"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000117",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0030159",
-                        "label": "signaling receptor complex adaptor activity"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "491"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "136"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000118",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:O14640",
-                        "label": "DVL1 Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "3225"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000119",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000353",
-                        "label": "physical interaction evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "with",
-                        "value": "UniProtKB:O70239"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-19"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:10330181"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000128",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003713",
-                        "label": "transcription coactivator activity"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "553"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "1222"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000142",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005829",
-                        "label": "cytosol"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001062",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0110165",
-                        "label": "cellular anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "Cellular Component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "2831.25"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000143",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000318",
-                        "label": "biological aspect of ancestor evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "GO_REF:0000033"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "with",
-                        "value": "PANTHER:PTN000093945"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-19"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000144",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005634",
-                        "label": "nucleus"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001062",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0110165",
-                        "label": "cellular anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "Cellular Component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "7162.5"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000145",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:10980594"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-19"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000146",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005886",
-                        "label": "plasma membrane"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001062",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0110165",
-                        "label": "cellular anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "Cellular Component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "862.5"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000147",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:16263759"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-19"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000166",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0030877",
-                        "label": "beta-catenin destruction complex"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "Cellular Component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0032991",
-                        "label": "protein-containing complex"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "263"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "672"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000167",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:O15169",
-                        "label": "AXIN1 Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "639"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "481"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000168",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:P25054",
-                        "label": "APC Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "1650"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000169",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:P49841",
-                        "label": "GSK3B Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "1256.25"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000170",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:P48729",
-                        "label": "CSNK1A1 Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "2043.75"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000171",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:11955436"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-19"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000172",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:16188939"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-19"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000173",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2017-07-19"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:16188939"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000174",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2017-07-19"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:16188939"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000175",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0004674",
-                        "label": "protein serine/threonine kinase activity"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "511"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "570"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000178",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:11955436"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-19"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000180",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005829",
-                        "label": "cytosol"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001062",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0110165",
-                        "label": "cellular anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "Cellular Component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "5587.5"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000181",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-19"
-                    },
-                    {
-                        "key": "source",
-                        "value": "GO_REF:0000052"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000182",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:1901800",
-                        "label": "positive regulation of proteasomal protein catabolic process"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008150",
-                        "label": "Biological Process"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "483"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "891"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000183",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:P35222",
-                        "label": "CTNNB1 Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "163"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "1398"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/596ef51500000184",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0060070",
-                        "label": "canonical Wnt signaling pathway"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0008150",
-                        "label": "Biological Process"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "949"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "45"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000217",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0048018",
-                        "label": "receptor ligand activity"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "10"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000220",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0042813",
-                        "label": "Wnt-activated receptor activity"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2018-10-01"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "234"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "7"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000221",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:Q9UP38",
-                        "label": "FZD1 Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "6768.75"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000222",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000303",
-                        "label": "author statement without traceable support used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:23461676"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-24"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000232",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:Q9UP38",
-                        "label": "FZD1 Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "4800"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000236",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000353",
-                        "label": "physical interaction evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:10557084"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-24"
-                    },
-                    {
-                        "key": "with",
-                        "value": "UniProtKB:Q9UP38"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000239",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000094",
-                        "label": "biological assay evidence"
-                    }
-                ],
-                "root-type": [],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:10557084"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-24"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000241",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000094",
-                        "label": "biological assay evidence"
-                    }
-                ],
-                "root-type": [],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2017-07-24"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:14739301"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000243",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000094",
-                        "label": "biological assay evidence"
-                    }
-                ],
-                "root-type": [],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-24"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:11113207"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000244",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000094",
-                        "label": "biological assay evidence"
-                    }
-                ],
-                "root-type": [],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-24"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:10644691"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000246",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000015",
-                        "label": "mutant phenotype evidence"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:11955436"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-24"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000248",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000353",
-                        "label": "physical interaction evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:10557084"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-25"
-                    },
-                    {
-                        "key": "with",
-                        "value": "UniProtKB:Q9UP38"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000250",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000353",
-                        "label": "physical interaction evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "with",
-                        "value": "UniProtKB:O70239"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-25"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:10330181"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000678",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005615",
-                        "label": "extracellular space"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001062",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0110165",
-                        "label": "cellular anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "Cellular Component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "hint-layout-x",
-                        "value": "4012.5"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5970219a00000679",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000318",
-                        "label": "biological aspect of ancestor evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "GO_REF:0000033"
-                    },
-                    {
-                        "key": "with",
-                        "value": "PANTHER:PTN000246517"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-07-31"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5993df9e00000344",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "UniProtKB:P56703",
-                        "label": "WNT3 Hsap"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi information biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36080",
-                        "label": "chebi protein"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "hint-layout-x",
-                        "value": "4406.25"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-24"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "hint-layout-y",
-                        "value": "75"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:596ef51500000088/5993df9e00000345",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000353",
-                        "label": "physical interaction evidence used in manual assertion"
-                    }
-                ],
-                "root-type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:10557084"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-08-22"
-                    },
-                    {
-                        "key": "with",
-                        "value": "UniProtKB:Q9UP38"
-                    }
-                ]
-            }
+  "packet-id": "57b88f654855a12e",
+  "provided-by": [],
+  "is-reasoned": false,
+  "intention": "query",
+  "signal": "rebuild",
+  "message-type": "success",
+  "message": "success",
+  "data": {
+    "modified-p": false,
+    "id": "gomodel:596ef51500000088",
+    "individuals": [
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000465",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:P35222",
+            "label": "CTNNB1 Hsap"
+          }
         ],
-        "facts": [
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000175",
-                "property": "RO:0002233",
-                "property-label": "has input",
-                "object": "gomodel:596ef51500000088/5b91dbd100000465",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5b91dbd100000470",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000128",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:596ef51500000088/596ef51500000184",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5970219a00000244",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000111",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:596ef51500000088/596ef51500000146",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/596ef51500000147",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/5970219a00000217",
-                "property": "RO:0002233",
-                "property-label": "has input",
-                "object": "gomodel:596ef51500000088/5970219a00000232",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5970219a00000248",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/5970219a00000217",
-                "property": "RO:0002629",
-                "property-label": "directly positively regulates",
-                "object": "gomodel:596ef51500000088/596ef51500000111",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-01"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000117",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:596ef51500000088/596ef51500000142",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/596ef51500000143",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000166",
-                "property": "BFO:0000051",
-                "property-label": "has part",
-                "object": "gomodel:596ef51500000088/596ef51500000167",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/596ef51500000173",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000111",
-                "property": "RO:0002629",
-                "property-label": "directly positively regulates",
-                "object": "gomodel:596ef51500000088/596ef51500000117",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-01"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/5970219a00000217",
-                "property": "RO:0002629",
-                "property-label": "directly positively regulates",
-                "object": "gomodel:596ef51500000088/5970219a00000220",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5970219a00000236",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000175",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:596ef51500000088/596ef51500000180",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/596ef51500000181",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/5970219a00000220",
-                "property": "RO:0002629",
-                "property-label": "directly positively regulates",
-                "object": "gomodel:596ef51500000088/596ef51500000117",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "GOC:pt"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2017-09-11"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000117",
-                "property": "RO:0002233",
-                "property-label": "has input",
-                "object": "gomodel:596ef51500000088/5b91dbd100000467",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5b91dbd100000469",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000182",
-                "property": "RO:0002233",
-                "property-label": "has input",
-                "object": "gomodel:596ef51500000088/5b91dbd100000466",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5b91dbd100000471",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000182",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:596ef51500000088/5b91dbd100000475",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5b91dbd100000478",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5b91dbd100000479",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-01"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000111",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:596ef51500000088/596ef51500000112",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/596ef51500000113",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000117",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:596ef51500000088/596ef51500000118",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/596ef51500000119",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000111",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:596ef51500000088/596ef51500000184",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5b91dbd100000505",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/5970219a00000220",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:596ef51500000088/596ef51500000184",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5970219a00000241",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000128",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:596ef51500000088/596ef51500000183",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5b91dbd100000472",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-09-30"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000166",
-                "property": "BFO:0000051",
-                "property-label": "has part",
-                "object": "gomodel:596ef51500000088/596ef51500000170",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/596ef51500000171",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/5970219a00000217",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:596ef51500000088/596ef51500000184",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5970219a00000239",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/5970219a00000220",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:596ef51500000088/5970219a00000221",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5970219a00000222",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000182",
-                "property": "RO:0002212",
-                "property-label": "negatively regulates",
-                "object": "gomodel:596ef51500000088/596ef51500000128",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5970219a00000246",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/5970219a00000217",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:596ef51500000088/5970219a00000678",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5970219a00000679",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000166",
-                "property": "BFO:0000051",
-                "property-label": "has part",
-                "object": "gomodel:596ef51500000088/596ef51500000168",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/596ef51500000174",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000128",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:596ef51500000088/596ef51500000144",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/596ef51500000145",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000166",
-                "property": "BFO:0000051",
-                "property-label": "has part",
-                "object": "gomodel:596ef51500000088/596ef51500000169",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/596ef51500000172",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000117",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:596ef51500000088/596ef51500000184",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5970219a00000243",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000175",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:596ef51500000088/596ef51500000182",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5b91dbd100000477",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-9074-3507"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-01"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://geneontology.org"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/5970219a00000220",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:596ef51500000088/5b91dbd100000514",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5b91dbd100000515",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2018-10-02"
-                    },
-                    {
-                        "key": "providedBy",
-                        "value": "http://www.wormbase.org"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000175",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:596ef51500000088/596ef51500000166",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/596ef51500000178",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/596ef51500000117",
-                "property": "RO:0002630",
-                "property-label": "directly negatively regulates",
-                "object": "gomodel:596ef51500000088/596ef51500000175",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5970219a00000250",
-                        "value-type": "IRI"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:596ef51500000088/5970219a00000217",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:596ef51500000088/5993df9e00000344",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:596ef51500000088/5993df9e00000345",
-                        "value-type": "IRI"
-                    }
-                ]
-            }
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
         ],
         "annotations": [
-            {
-                "key": "state",
-                "value": "development"
-            },
-            {
-                "key": "contributor",
-                "value": "GOC:pt"
-            },
-            {
-                "key": "contributor",
-                "value": "http://orcid.org/0000-0002-1706-4196"
-            },
-            {
-                "key": "contributor",
-                "value": "http://orcid.org/0000-0002-7073-9172"
-            },
-            {
-                "key": "contributor",
-                "value": "http://orcid.org/0000-0002-9074-3507"
-            },
-            {
-                "key": "date",
-                "value": "2018-10-02"
-            },
-            {
-                "key": "title",
-                "value": "canonical wnt using companions"
-            },
-            {
-                "key": "providedBy",
-                "value": "http://geneontology.org"
-            },
-            {
-                "key": "providedBy",
-                "value": "http://www.wormbase.org"
-            },
-            {
-                "key": "http://www.geneontology.org/formats/oboInOwl#id",
-                "value": "gomodel:596ef51500000088"
-            },
-            {
-                "key": "https://w3id.org/biolink/vocab/in_taxon",
-                "value": "NCBITaxon:9606",
-                "value-type": "IRI"
-            }
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          }
         ]
-    }
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000466",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:P35222",
+            "label": "CTNNB1 Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000467",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:O15169",
+            "label": "AXIN1 Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000469",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000353",
+            "label": "physical interaction evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "UniProtKB:O70239"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "source",
+            "value": "PMID:10330181"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000470",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "source",
+            "value": "PMID:11955436"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000471",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "source",
+            "value": "PMID:11955436"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000472",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "source",
+            "value": "PMID:9065402"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000475",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0090090",
+            "label": "negative regulation of canonical Wnt signaling pathway"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "GO:0008150",
+            "label": "Biological Process"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "287"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "896.625"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000477",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:11955436"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-01"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000478",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-01"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "source",
+            "value": "PMID:10644691"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000479",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2018-10-01"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "source",
+            "value": "PMID:22899650"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000505",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "source",
+            "value": "PMID:11029007"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000514",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005886",
+            "label": "plasma membrane"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001062",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0110165",
+            "label": "cellular anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "Cellular Component"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5b91dbd100000515",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000318",
+            "label": "biological aspect of ancestor evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "with",
+            "value": "PANTHER:PTN000139394"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "source",
+            "value": "GO_REF:0000033"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000111",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0015026",
+            "label": "coreceptor activity"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "215"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "305"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-7073-9172"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000112",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:O75581",
+            "label": "LRP6 Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "468.75"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000113",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-19"
+          },
+          {
+            "key": "source",
+            "value": "PMID:11029007"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000117",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0030159",
+            "label": "signaling receptor complex adaptor activity"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "491"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "136"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000118",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:O14640",
+            "label": "DVL1 Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "3225"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000119",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000353",
+            "label": "physical interaction evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "with",
+            "value": "UniProtKB:O70239"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-19"
+          },
+          {
+            "key": "source",
+            "value": "PMID:10330181"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000128",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0003713",
+            "label": "transcription coactivator activity"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "553"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "1222"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000142",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005829",
+            "label": "cytosol"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001062",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0110165",
+            "label": "cellular anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "Cellular Component"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "2831.25"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000143",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000318",
+            "label": "biological aspect of ancestor evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "GO_REF:0000033"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "with",
+            "value": "PANTHER:PTN000093945"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-19"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000144",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005634",
+            "label": "nucleus"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001062",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0110165",
+            "label": "cellular anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "Cellular Component"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "7162.5"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000145",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "source",
+            "value": "PMID:10980594"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-19"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000146",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005886",
+            "label": "plasma membrane"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001062",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0110165",
+            "label": "cellular anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "Cellular Component"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "862.5"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000147",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "source",
+            "value": "PMID:16263759"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-19"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000166",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0030877",
+            "label": "beta-catenin destruction complex"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "Cellular Component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0032991",
+            "label": "protein-containing complex"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "263"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "672"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000167",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:O15169",
+            "label": "AXIN1 Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "639"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "481"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000168",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:P25054",
+            "label": "APC Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "1650"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000169",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:P49841",
+            "label": "GSK3B Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "1256.25"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000170",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:P48729",
+            "label": "CSNK1A1 Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "2043.75"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000171",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "source",
+            "value": "PMID:11955436"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-19"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000172",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "source",
+            "value": "PMID:16188939"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-19"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000173",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2017-07-19"
+          },
+          {
+            "key": "source",
+            "value": "PMID:16188939"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000174",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2017-07-19"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "source",
+            "value": "PMID:16188939"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000175",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0004674",
+            "label": "protein serine/threonine kinase activity"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "511"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "570"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000178",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:11955436"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-19"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000180",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005829",
+            "label": "cytosol"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001062",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0110165",
+            "label": "cellular anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "Cellular Component"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "5587.5"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000181",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-19"
+          },
+          {
+            "key": "source",
+            "value": "GO_REF:0000052"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000182",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:1901800",
+            "label": "positive regulation of proteasomal protein catabolic process"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "GO:0008150",
+            "label": "Biological Process"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "483"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "891"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000183",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:P35222",
+            "label": "CTNNB1 Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "163"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "1398"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/596ef51500000184",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0060070",
+            "label": "canonical Wnt signaling pathway"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "GO:0008150",
+            "label": "Biological Process"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "949"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "45"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000217",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0048018",
+            "label": "receptor ligand activity"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "10"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000220",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0042813",
+            "label": "Wnt-activated receptor activity"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2018-10-01"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "234"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "7"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000221",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:Q9UP38",
+            "label": "FZD1 Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "6768.75"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000222",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000303",
+            "label": "author statement without traceable support used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "source",
+            "value": "PMID:23461676"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-24"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000232",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:Q9UP38",
+            "label": "FZD1 Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "4800"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000236",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000353",
+            "label": "physical interaction evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:10557084"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-24"
+          },
+          {
+            "key": "with",
+            "value": "UniProtKB:Q9UP38"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000239",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000094",
+            "label": "biological assay evidence"
+          }
+        ],
+        "root-type": [],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "source",
+            "value": "PMID:10557084"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-24"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000241",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000094",
+            "label": "biological assay evidence"
+          }
+        ],
+        "root-type": [],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2017-07-24"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "source",
+            "value": "PMID:14739301"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000243",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000094",
+            "label": "biological assay evidence"
+          }
+        ],
+        "root-type": [],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-24"
+          },
+          {
+            "key": "source",
+            "value": "PMID:11113207"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000244",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000094",
+            "label": "biological assay evidence"
+          }
+        ],
+        "root-type": [],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-24"
+          },
+          {
+            "key": "source",
+            "value": "PMID:10644691"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000246",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000015",
+            "label": "mutant phenotype evidence"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:11955436"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-24"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000248",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000353",
+            "label": "physical interaction evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:10557084"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-25"
+          },
+          {
+            "key": "with",
+            "value": "UniProtKB:Q9UP38"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000250",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000353",
+            "label": "physical interaction evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "with",
+            "value": "UniProtKB:O70239"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-25"
+          },
+          {
+            "key": "source",
+            "value": "PMID:10330181"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000678",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005615",
+            "label": "extracellular space"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001062",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0110165",
+            "label": "cellular anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "Cellular Component"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "hint-layout-x",
+            "value": "4012.5"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5970219a00000679",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000318",
+            "label": "biological aspect of ancestor evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "GO_REF:0000033"
+          },
+          {
+            "key": "with",
+            "value": "PANTHER:PTN000246517"
+          },
+          {
+            "key": "date",
+            "value": "2017-07-31"
+          },
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5993df9e00000344",
+        "type": [
+          {
+            "type": "class",
+            "id": "UniProtKB:P56703",
+            "label": "WNT3 Hsap"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi information biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "chebi protein"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "hint-layout-x",
+            "value": "4406.25"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-24"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "hint-layout-y",
+            "value": "75"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:596ef51500000088/5993df9e00000345",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000353",
+            "label": "physical interaction evidence used in manual assertion"
+          }
+        ],
+        "root-type": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "source",
+            "value": "PMID:10557084"
+          },
+          {
+            "key": "date",
+            "value": "2017-08-22"
+          },
+          {
+            "key": "with",
+            "value": "UniProtKB:Q9UP38"
+          }
+        ]
+      }
+    ],
+    "facts": [
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000175",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:596ef51500000088/5b91dbd100000465",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5b91dbd100000470",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000128",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:596ef51500000088/596ef51500000184",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5970219a00000244",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000111",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:596ef51500000088/596ef51500000146",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/596ef51500000147",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/5970219a00000217",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:596ef51500000088/5970219a00000232",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5970219a00000248",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/5970219a00000217",
+        "property": "RO:0002629",
+        "property-label": "directly positively regulates",
+        "object": "gomodel:596ef51500000088/596ef51500000111",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-01"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000117",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:596ef51500000088/596ef51500000142",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/596ef51500000143",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000166",
+        "property": "BFO:0000051",
+        "property-label": "has part",
+        "object": "gomodel:596ef51500000088/596ef51500000167",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/596ef51500000173",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000111",
+        "property": "RO:0002629",
+        "property-label": "directly positively regulates",
+        "object": "gomodel:596ef51500000088/596ef51500000117",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-01"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/5970219a00000217",
+        "property": "RO:0002629",
+        "property-label": "directly positively regulates",
+        "object": "gomodel:596ef51500000088/5970219a00000220",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5970219a00000236",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000175",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:596ef51500000088/596ef51500000180",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/596ef51500000181",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/5970219a00000220",
+        "property": "RO:0002629",
+        "property-label": "directly positively regulates",
+        "object": "gomodel:596ef51500000088/596ef51500000117",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "GOC:pt"
+          },
+          {
+            "key": "date",
+            "value": "2017-09-11"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000117",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:596ef51500000088/5b91dbd100000467",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5b91dbd100000469",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000182",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:596ef51500000088/5b91dbd100000466",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5b91dbd100000471",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000182",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:596ef51500000088/5b91dbd100000475",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5b91dbd100000478",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5b91dbd100000479",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-01"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000111",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:596ef51500000088/596ef51500000112",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/596ef51500000113",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000117",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:596ef51500000088/596ef51500000118",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/596ef51500000119",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000111",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:596ef51500000088/596ef51500000184",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5b91dbd100000505",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/5970219a00000220",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:596ef51500000088/596ef51500000184",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5970219a00000241",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000128",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:596ef51500000088/596ef51500000183",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5b91dbd100000472",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2018-09-30"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000166",
+        "property": "BFO:0000051",
+        "property-label": "has part",
+        "object": "gomodel:596ef51500000088/596ef51500000170",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/596ef51500000171",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/5970219a00000217",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:596ef51500000088/596ef51500000184",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5970219a00000239",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/5970219a00000220",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:596ef51500000088/5970219a00000221",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5970219a00000222",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000182",
+        "property": "RO:0002212",
+        "property-label": "negatively regulates",
+        "object": "gomodel:596ef51500000088/596ef51500000128",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5970219a00000246",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/5970219a00000217",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:596ef51500000088/5970219a00000678",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5970219a00000679",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000166",
+        "property": "BFO:0000051",
+        "property-label": "has part",
+        "object": "gomodel:596ef51500000088/596ef51500000168",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/596ef51500000174",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000128",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:596ef51500000088/596ef51500000144",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/596ef51500000145",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000166",
+        "property": "BFO:0000051",
+        "property-label": "has part",
+        "object": "gomodel:596ef51500000088/596ef51500000169",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/596ef51500000172",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000117",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:596ef51500000088/596ef51500000184",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5970219a00000243",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000175",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:596ef51500000088/596ef51500000182",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5b91dbd100000477",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-9074-3507"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-01"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://geneontology.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/5970219a00000220",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:596ef51500000088/5b91dbd100000514",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5b91dbd100000515",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2018-10-02"
+          },
+          {
+            "key": "providedBy",
+            "value": "http://www.wormbase.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000175",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:596ef51500000088/596ef51500000166",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/596ef51500000178",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/596ef51500000117",
+        "property": "RO:0002630",
+        "property-label": "directly negatively regulates",
+        "object": "gomodel:596ef51500000088/596ef51500000175",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5970219a00000250",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:596ef51500000088/5970219a00000217",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:596ef51500000088/5993df9e00000344",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:596ef51500000088/5993df9e00000345",
+            "value-type": "IRI"
+          }
+        ]
+      }
+    ],
+    "annotations": [
+      {
+        "key": "state",
+        "value": "development"
+      },
+      {
+        "key": "contributor",
+        "value": "GOC:pt"
+      },
+      {
+        "key": "contributor",
+        "value": "http://orcid.org/0000-0002-1706-4196"
+      },
+      {
+        "key": "contributor",
+        "value": "http://orcid.org/0000-0002-7073-9172"
+      },
+      {
+        "key": "contributor",
+        "value": "http://orcid.org/0000-0002-9074-3507"
+      },
+      {
+        "key": "date",
+        "value": "2018-10-02"
+      },
+      {
+        "key": "title",
+        "value": "canonical wnt using companions"
+      },
+      {
+        "key": "providedBy",
+        "value": "http://geneontology.org"
+      },
+      {
+        "key": "providedBy",
+        "value": "http://www.wormbase.org"
+      },
+      {
+        "key": "http://www.geneontology.org/formats/oboInOwl#id",
+        "value": "gomodel:596ef51500000088"
+      },
+      {
+        "key": "https://w3id.org/biolink/vocab/in_taxon",
+        "value": "NCBITaxon:9606",
+        "value-type": "IRI"
+      }
+    ]
+  }
 }

--- a/packages/bbop-graph-noctua/src/fixtures/response-gomodel-5d88482400000052-2019-09-25.json
+++ b/packages/bbop-graph-noctua/src/fixtures/response-gomodel-5d88482400000052-2019-09-25.json
@@ -1,0 +1,4691 @@
+{
+    "packet-id": "137084cc46d74214",
+    "provided-by": [],
+    "is-reasoned": true,
+    "intention": "query",
+    "signal": "rebuild",
+    "message-type": "success",
+    "message": "success",
+    "data": {
+        "modified-p": false,
+        "validation-results": {
+            "is-conformant": false,
+            "owl-validation": {
+                "id": "OWL_REASONER",
+                "is-conformant": true,
+                "tracker": "https://github.com/geneontology/helpdesk/issues",
+                "rule-file": "https://github.com/geneontology/go-ontology"
+            },
+            "shex-validation": {
+                "node-matched-shapes": {
+                    "gomodel:5d88482400000052/5d88482400000088": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000087": [
+                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000101": [
+                        "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000089": [
+                        "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000102": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000105": [
+                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000060": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000084": [
+                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000083": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000061": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000063": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000085": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000117": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000099": [
+                        "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000077": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000076": [
+                        "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000098": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000112": [
+                        "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000079": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000111": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000114": [
+                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000058": [
+                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000113": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000116": [
+                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000115": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000091": [
+                        "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000092": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000073": [
+                        "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000095": [
+                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000094": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000053": [
+                        "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000097": [
+                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000075": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000096": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000107": [
+                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000106": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000109": [
+                        "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
+                    ],
+                    "gomodel:5d88482400000052/5d88482400000108": [
+                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+                    ]
+                },
+                "is-conformant": false,
+                "tracker": "https://github.com/geneontology/go-shapes/issues",
+                "rule-file": "https://github.com/geneontology/go-shapes/blob/master/shapes/go-cam-shapes.shex",
+                "violations": [
+                    {
+                        "explanations": [
+                            {
+                                "shape": "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction",
+                                "constraints": [
+                                    {
+                                        "object": "gomodel:5d88482400000052/5d88482400000082",
+                                        "property": "RO:0002418",
+                                        "intended-range-shapes": [
+                                            "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "node": "gomodel:5d88482400000052/5d88482400000080"
+                    },
+                    {
+                        "explanations": [],
+                        "node": "gomodel:5d88482400000052/5d88482400000093"
+                    }
+                ]
+            }
+        },
+        "id": "gomodel:5d88482400000052",
+        "individuals": [
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000053",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0004674",
+                        "label": "protein serine/threonine kinase activity"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0004672",
+                        "label": "protein kinase activity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000003",
+                        "label": "occurrent"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0016772",
+                        "label": "transferase activity, transferring phosphorus-containing groups"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0016773",
+                        "label": "phosphotransferase activity, alcohol group as acceptor"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0016740",
+                        "label": "transferase activity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0004674",
+                        "label": "protein serine/threonine kinase activity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0016301",
+                        "label": "kinase activity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0140096",
+                        "label": "catalytic activity, acting on a protein"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0003824",
+                        "label": "catalytic activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-24"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000054",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00003401",
+                        "label": "mpk-1 Cele"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33582",
+                        "label": "carbon group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33694",
+                        "label": "biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36357",
+                        "label": "polyatomic entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi gene"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33675",
+                        "label": "p-block molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00003401",
+                        "label": "mpk-1 Cele"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33579",
+                        "label": "main group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33839",
+                        "label": "macromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:50860",
+                        "label": "organic molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:23367",
+                        "label": "molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-24"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000058",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005813",
+                        "label": "centrosome"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "GO:0044422",
+                        "label": "organelle part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044424",
+                        "label": "intracellular part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044446",
+                        "label": "intracellular organelle part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0030000",
+                        "label": "biological entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044430",
+                        "label": "cytoskeletal part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044464",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "cellular_component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005813",
+                        "label": "centrosome"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005815",
+                        "label": "microtubule organizing center"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000006",
+                        "label": "material anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000003",
+                        "label": "connected anatomical structure"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000014",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-24"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000060",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:31296532"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-24"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000061",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000015",
+                        "label": "mutant phenotype evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000059",
+                        "label": "experimental phenotypic evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-24"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:1236758"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000063",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-24"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:31296532"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000067",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:78686",
+                        "label": "Delta(4)-dafachronic acid"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36586",
+                        "label": "carbonyl compound"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33595",
+                        "label": "cyclic compound"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36587",
+                        "label": "organic oxo compound"
+                    },
+                    {
+                        "type": "class",
+                        "id": "obo:GOCHE_37527",
+                        "label": "substance with acid role"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33674",
+                        "label": "s-block molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33675",
+                        "label": "p-block molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33832",
+                        "label": "organic cyclic compound"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33635",
+                        "label": "polycyclic compound"
+                    },
+                    {
+                        "type": "class",
+                        "id": "obo:GOCHE_50906",
+                        "label": "substance with role role"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:3992",
+                        "label": "cyclic ketone"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:35341",
+                        "label": "steroid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33285",
+                        "label": "heteroorganic entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:47909",
+                        "label": "3-oxo-Delta(4) steroid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36357",
+                        "label": "polyatomic entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:35789",
+                        "label": "oxo steroid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:25384",
+                        "label": "monocarboxylic acid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24651",
+                        "label": "hydroxides"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:72695",
+                        "label": "organic molecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:23367",
+                        "label": "molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:50401",
+                        "label": "cholestanoid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "obo:GOCHE_48705",
+                        "label": "substance with agonist role"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "obo:GOCHE_24432",
+                        "label": "substance with biological role role"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36962",
+                        "label": "organochalcogen compound"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:37577",
+                        "label": "heteroatomic molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:18059",
+                        "label": "lipid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33575",
+                        "label": "carboxylic acid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36963",
+                        "label": "organooxygen compound"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:51958",
+                        "label": "organic polycyclic compound"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33579",
+                        "label": "main group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:131619",
+                        "label": "C27-steroid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33608",
+                        "label": "hydrogen molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:51689",
+                        "label": "enone"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:51721",
+                        "label": "alpha,beta-unsaturated ketone"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:47788",
+                        "label": "3-oxo steroid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:26764",
+                        "label": "steroid hormone"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:17087",
+                        "label": "ketone"
+                    },
+                    {
+                        "type": "class",
+                        "id": "obo:GOCHE_24621",
+                        "label": "substance with hormone role"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:78686",
+                        "label": "Delta(4)-dafachronic acid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:78840",
+                        "label": "olefinic compound"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:64709",
+                        "label": "organic acid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33582",
+                        "label": "carbon group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "obo:GOCHE_51086",
+                        "label": "substance with chemical role role"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33304",
+                        "label": "chalcogen molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:35605",
+                        "label": "carbon oxoacid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "obo:GOCHE_17891",
+                        "label": "substance with donor role"
+                    },
+                    {
+                        "type": "class",
+                        "id": "obo:GOCHE_52210",
+                        "label": "substance with pharmacological role role"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:47891",
+                        "label": "steroid acid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:50860",
+                        "label": "organic molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "obo:GOCHE_39141",
+                        "label": "substance with Bronsted acid role"
+                    },
+                    {
+                        "type": "class",
+                        "id": "obo:GOCHE_33280",
+                        "label": "substance with molecular messenger role"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:25367",
+                        "label": "molecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24833",
+                        "label": "oxoacid"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:78698",
+                        "label": "dafachronic acids"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:25806",
+                        "label": "oxygen molecular entity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-24"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000073",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005484",
+                        "label": "SNAP receptor activity"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000003",
+                        "label": "occurrent"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005488",
+                        "label": "binding"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005515",
+                        "label": "protein binding"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005484",
+                        "label": "SNAP receptor activity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000074",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00005193",
+                        "label": "srg-36 Cele"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33582",
+                        "label": "carbon group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33694",
+                        "label": "biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36357",
+                        "label": "polyatomic entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi gene"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33675",
+                        "label": "p-block molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33579",
+                        "label": "main group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00005193",
+                        "label": "srg-36 Cele"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33839",
+                        "label": "macromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:50860",
+                        "label": "organic molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:23367",
+                        "label": "molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000075",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:138"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000076",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0023052",
+                        "label": "signaling"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000003",
+                        "label": "occurrent"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0008150",
+                        "label": "Biological Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0023052",
+                        "label": "signaling"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000077",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000015",
+                        "label": "mutant phenotype evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000059",
+                        "label": "experimental phenotypic evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:138"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000078",
+                "type": [
+                    {
+                        "type": "complement",
+                        "filler": {
+                            "type": "class",
+                            "id": "GO:0005886",
+                            "label": "plasma membrane"
+                        }
+                    }
+                ],
+                "inferred-type": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000079",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:139"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000080",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000003",
+                        "label": "occurrent"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000081",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00005194",
+                        "label": "srg-37 Cele"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33582",
+                        "label": "carbon group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33694",
+                        "label": "biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36357",
+                        "label": "polyatomic entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi gene"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33675",
+                        "label": "p-block molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33579",
+                        "label": "main group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00005194",
+                        "label": "srg-37 Cele"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33839",
+                        "label": "macromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:50860",
+                        "label": "organic molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:23367",
+                        "label": "molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000082",
+                "type": [
+                    {
+                        "type": "complement",
+                        "filler": {
+                            "type": "class",
+                            "id": "GO:0071291",
+                            "label": "cellular response to selenium ion"
+                        }
+                    }
+                ],
+                "inferred-type": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000003",
+                        "label": "occurrent"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000083",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000015",
+                        "label": "mutant phenotype evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000059",
+                        "label": "experimental phenotypic evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:141"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000084",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005886",
+                        "label": "plasma membrane"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CARO:0030000",
+                        "label": "biological entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044464",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "cellular_component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005886",
+                        "label": "plasma membrane"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000006",
+                        "label": "material anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000003",
+                        "label": "connected anatomical structure"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000014",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0016020",
+                        "label": "membrane"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000085",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:141"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000086",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00004053",
+                        "label": "tank-1 Cele"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33582",
+                        "label": "carbon group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33694",
+                        "label": "biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36357",
+                        "label": "polyatomic entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi gene"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33675",
+                        "label": "p-block molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33579",
+                        "label": "main group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00004053",
+                        "label": "tank-1 Cele"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33839",
+                        "label": "macromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:50860",
+                        "label": "organic molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:23367",
+                        "label": "molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000087",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005829",
+                        "label": "cytosol"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "GO:0044444",
+                        "label": "cytoplasmic part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044424",
+                        "label": "intracellular part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0030000",
+                        "label": "biological entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044464",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "cellular_component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000006",
+                        "label": "material anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000003",
+                        "label": "connected anatomical structure"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000014",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005829",
+                        "label": "cytosol"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000088",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:153"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000089",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000003",
+                        "label": "occurrent"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000090",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00003168",
+                        "label": "mec-4 Cele"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33582",
+                        "label": "carbon group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33694",
+                        "label": "biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36357",
+                        "label": "polyatomic entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi gene"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33675",
+                        "label": "p-block molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00003168",
+                        "label": "mec-4 Cele"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33579",
+                        "label": "main group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33839",
+                        "label": "macromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:50860",
+                        "label": "organic molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:23367",
+                        "label": "molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000091",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0070656",
+                        "label": "mechanoreceptor differentiation involved in mechanosensory epithelium regeneration"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "GO:0070656",
+                        "label": "mechanoreceptor differentiation involved in mechanosensory epithelium regeneration"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0048869",
+                        "label": "cellular developmental process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0009987",
+                        "label": "cellular process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000003",
+                        "label": "occurrent"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0032502",
+                        "label": "developmental process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0042490",
+                        "label": "mechanoreceptor differentiation"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0008150",
+                        "label": "Biological Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0030182",
+                        "label": "neuron differentiation"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0030154",
+                        "label": "cell differentiation"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000092",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000015",
+                        "label": "mutant phenotype evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000059",
+                        "label": "experimental phenotypic evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:219"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000093",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005886",
+                        "label": "plasma membrane"
+                    }
+                ],
+                "inferred-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005886",
+                        "label": "plasma membrane"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0097458",
+                        "label": "neuron part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044441",
+                        "label": "ciliary part"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "GO:0044422",
+                        "label": "organelle part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0120038",
+                        "label": "plasma membrane bounded cell projection part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0030000",
+                        "label": "biological entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044463",
+                        "label": "cell projection part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044441",
+                        "label": "ciliary part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044464",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "cellular_component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005886",
+                        "label": "plasma membrane"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000006",
+                        "label": "material anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000003",
+                        "label": "connected anatomical structure"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000014",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0097458",
+                        "label": "neuron part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0016020",
+                        "label": "membrane"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000094",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:219"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000095",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "WBbt:0003679",
+                        "label": "neuron"
+                    }
+                ],
+                "inferred-type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001062",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WBbt:0003679",
+                        "label": "neuron"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000540",
+                        "label": "neuron"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CARO:0030000",
+                        "label": "biological entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0002319",
+                        "label": "neural cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001062",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WBbt:0003679",
+                        "label": "neuron"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005623",
+                        "label": "cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000255",
+                        "label": "eukaryotic cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000211",
+                        "label": "electrically active cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000006",
+                        "label": "material anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000003",
+                        "label": "connected anatomical structure"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0002371",
+                        "label": "somatic cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WBbt:0000100",
+                        "label": "C. elegans Cell and Anatomy"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000393",
+                        "label": "electrically responsive cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000404",
+                        "label": "electrically signaling cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000548",
+                        "label": "animal cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WBbt:0004017",
+                        "label": "Cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "cellular_component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000003",
+                        "label": "native cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000000",
+                        "label": "cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000540",
+                        "label": "neuron"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000096",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:219"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000097",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005929",
+                        "label": "cilium"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "GO:0043226",
+                        "label": "organelle"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0042995",
+                        "label": "cell projection"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0120025",
+                        "label": "plasma membrane bounded cell projection"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0030000",
+                        "label": "biological entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044464",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "cellular_component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000006",
+                        "label": "material anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000003",
+                        "label": "connected anatomical structure"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000014",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005929",
+                        "label": "cilium"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000098",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:223"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000099",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000003",
+                        "label": "occurrent"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000100",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00000002",
+                        "label": "aat-1 Cele"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33582",
+                        "label": "carbon group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33694",
+                        "label": "biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36357",
+                        "label": "polyatomic entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi gene"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33675",
+                        "label": "p-block molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00000002",
+                        "label": "aat-1 Cele"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33579",
+                        "label": "main group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33839",
+                        "label": "macromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:50860",
+                        "label": "organic molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:23367",
+                        "label": "molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000101",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0010267",
+                        "label": "production of ta-siRNAs involved in RNA interference"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "GO:0044238",
+                        "label": "primary metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044237",
+                        "label": "cellular metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0071704",
+                        "label": "organic substance metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0008152",
+                        "label": "metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:1901360",
+                        "label": "organic cyclic compound metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0070918",
+                        "label": "production of small RNA involved in gene silencing by RNA"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0008150",
+                        "label": "Biological Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0046483",
+                        "label": "heterocycle metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0006396",
+                        "label": "RNA processing"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0009987",
+                        "label": "cellular process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000003",
+                        "label": "occurrent"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0030422",
+                        "label": "production of siRNA involved in RNA interference"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0010267",
+                        "label": "production of ta-siRNAs involved in RNA interference"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0043170",
+                        "label": "macromolecule metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0006139",
+                        "label": "nucleobase-containing compound metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0016070",
+                        "label": "RNA metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0090304",
+                        "label": "nucleic acid metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0006725",
+                        "label": "cellular aromatic compound metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0031050",
+                        "label": "dsRNA processing"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0034641",
+                        "label": "cellular nitrogen compound metabolic process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0006807",
+                        "label": "nitrogen compound metabolic process"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000102",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000015",
+                        "label": "mutant phenotype evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000059",
+                        "label": "experimental phenotypic evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:1236758"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000104",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00000003",
+                        "label": "aat-2 Cele"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33582",
+                        "label": "carbon group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33694",
+                        "label": "biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36357",
+                        "label": "polyatomic entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi gene"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00000003",
+                        "label": "aat-2 Cele"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33675",
+                        "label": "p-block molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33579",
+                        "label": "main group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33839",
+                        "label": "macromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:50860",
+                        "label": "organic molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:23367",
+                        "label": "molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000105",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005886",
+                        "label": "plasma membrane"
+                    }
+                ],
+                "inferred-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005886",
+                        "label": "plasma membrane"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044441",
+                        "label": "ciliary part"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "GO:0044422",
+                        "label": "organelle part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0120038",
+                        "label": "plasma membrane bounded cell projection part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0030000",
+                        "label": "biological entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044463",
+                        "label": "cell projection part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044441",
+                        "label": "ciliary part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044464",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "cellular_component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005886",
+                        "label": "plasma membrane"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000006",
+                        "label": "material anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000003",
+                        "label": "connected anatomical structure"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000014",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0016020",
+                        "label": "membrane"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000106",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:138"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000107",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005929",
+                        "label": "cilium"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "GO:0043226",
+                        "label": "organelle"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0042995",
+                        "label": "cell projection"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0120025",
+                        "label": "plasma membrane bounded cell projection"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0030000",
+                        "label": "biological entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044464",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "cellular_component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000006",
+                        "label": "material anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000003",
+                        "label": "connected anatomical structure"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000014",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005929",
+                        "label": "cilium"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000108",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:138"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000109",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0005215",
+                        "label": "transporter activity"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000003",
+                        "label": "occurrent"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005215",
+                        "label": "transporter activity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0003674",
+                        "label": "Molecular Function"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000110",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00000004",
+                        "label": "aat-3 Cele"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33582",
+                        "label": "carbon group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33694",
+                        "label": "biomacromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:36357",
+                        "label": "polyatomic entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33695",
+                        "label": "chebi gene"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WB:WBGene00000004",
+                        "label": "aat-3 Cele"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33675",
+                        "label": "p-block molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33579",
+                        "label": "main group molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:33839",
+                        "label": "macromolecule"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:50860",
+                        "label": "organic molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:24431",
+                        "label": "chemical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CHEBI:23367",
+                        "label": "molecular entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000111",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:138"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000112",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:1900285",
+                        "label": "regulation of cellotriose transport"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "BFO:0000015",
+                        "label": "Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000003",
+                        "label": "occurrent"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0050789",
+                        "label": "regulation of biological process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0032879",
+                        "label": "regulation of localization"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0008150",
+                        "label": "Biological Process"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0065007",
+                        "label": "biological regulation"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:1900285",
+                        "label": "regulation of cellotriose transport"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0051049",
+                        "label": "regulation of transport"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000113",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000315",
+                        "label": "mutant phenotype evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000015",
+                        "label": "mutant phenotype evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000059",
+                        "label": "experimental phenotypic evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "source",
+                        "value": "PMID:1236758"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000114",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0098590",
+                        "label": "plasma membrane region"
+                    }
+                ],
+                "inferred-type": [
+                    {
+                        "type": "class",
+                        "id": "GO:0098590",
+                        "label": "plasma membrane region"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0097458",
+                        "label": "neuron part"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "GO:0044425",
+                        "label": "membrane part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044459",
+                        "label": "plasma membrane part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0030000",
+                        "label": "biological entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0044464",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0098590",
+                        "label": "plasma membrane region"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "cellular_component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000006",
+                        "label": "material anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000003",
+                        "label": "connected anatomical structure"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000014",
+                        "label": "cell part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0097458",
+                        "label": "neuron part"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0016020",
+                        "label": "membrane"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000115",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:138"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000116",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "WBbt:0005394",
+                        "label": "amphid neuron"
+                    }
+                ],
+                "inferred-type": [
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001062",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000540",
+                        "label": "neuron"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WBbt:0005394",
+                        "label": "amphid neuron"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "CARO:0030000",
+                        "label": "biological entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000000",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0002319",
+                        "label": "neural cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "UBERON:0001062",
+                        "label": "anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WBbt:0003679",
+                        "label": "neuron"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005623",
+                        "label": "cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000255",
+                        "label": "eukaryotic cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000211",
+                        "label": "electrically active cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000006",
+                        "label": "material anatomical entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WBbt:0005394",
+                        "label": "amphid neuron"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CARO:0000003",
+                        "label": "connected anatomical structure"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0002371",
+                        "label": "somatic cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WBbt:0000100",
+                        "label": "C. elegans Cell and Anatomy"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000393",
+                        "label": "electrically responsive cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000030",
+                        "label": "object"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WBbt:0006816",
+                        "label": "ciliated neuron"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000004",
+                        "label": "independent continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000404",
+                        "label": "electrically signaling cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000002",
+                        "label": "continuant"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000548",
+                        "label": "animal cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "WBbt:0004017",
+                        "label": "Cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000001",
+                        "label": "entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "GO:0005575",
+                        "label": "cellular_component"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000003",
+                        "label": "native cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "BFO:0000040",
+                        "label": "material entity"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000000",
+                        "label": "cell"
+                    },
+                    {
+                        "type": "class",
+                        "id": "CL:0000540",
+                        "label": "neuron"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "id": "gomodel:5d88482400000052/5d88482400000117",
+                "type": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    }
+                ],
+                "inferred-type-with-all": [
+                    {
+                        "type": "class",
+                        "id": "ECO:0000000",
+                        "label": "evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000002",
+                        "label": "direct assay evidence"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000314",
+                        "label": "direct assay evidence used in manual assertion"
+                    },
+                    {
+                        "type": "class",
+                        "id": "ECO:0000006",
+                        "label": "experimental evidence"
+                    }
+                ],
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    },
+                    {
+                        "key": "source",
+                        "value": "PMID:138"
+                    }
+                ]
+            }
+        ],
+        "facts": [
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000082",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:5d88482400000052/5d88482400000084",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000085",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000073",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:5d88482400000052/5d88482400000074",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000075",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000053",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:5d88482400000052/5d88482400000058",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000063",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-24"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000105",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:5d88482400000052/5d88482400000107",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000108",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000089",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:5d88482400000052/5d88482400000090",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000104",
+                "property": "RO:0001025",
+                "property-label": "located_in",
+                "object": "gomodel:5d88482400000052/5d88482400000105",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000106",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000073",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:5d88482400000052/5d88482400000076",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000077",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000073",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:5d88482400000052/5d88482400000078",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000079",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000114",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:5d88482400000052/5d88482400000116",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000117",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000086",
+                "property": "RO:0001025",
+                "property-label": "located_in",
+                "object": "gomodel:5d88482400000052/5d88482400000087",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000088",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000091",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:5d88482400000052/5d88482400000093",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000094",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000080",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:5d88482400000052/5d88482400000081",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000109",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:5d88482400000052/5d88482400000110",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000111",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000099",
+                "property": "RO:0002418",
+                "property-label": "causally upstream of or within",
+                "object": "gomodel:5d88482400000052/5d88482400000101",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000102",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000093",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:5d88482400000052/5d88482400000097",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000098",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000093",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:5d88482400000052/5d88482400000095",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000096",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000080",
+                "property": "RO:0002418",
+                "property-label": "causally upstream of or within",
+                "object": "gomodel:5d88482400000052/5d88482400000082",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000083",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000053",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:5d88482400000052/5d88482400000054",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000060",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000061",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-24"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000109",
+                "property": "BFO:0000050",
+                "property-label": "part of",
+                "object": "gomodel:5d88482400000052/5d88482400000112",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000113",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000089",
+                "property": "RO:0002418",
+                "property-label": "causally upstream of or within",
+                "object": "gomodel:5d88482400000052/5d88482400000091",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000092",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000099",
+                "property": "RO:0002333",
+                "property-label": "enabled by",
+                "object": "gomodel:5d88482400000052/5d88482400000100",
+                "annotations": [
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            },
+            {
+                "subject": "gomodel:5d88482400000052/5d88482400000109",
+                "property": "BFO:0000066",
+                "property-label": "occurs in",
+                "object": "gomodel:5d88482400000052/5d88482400000114",
+                "annotations": [
+                    {
+                        "key": "evidence",
+                        "value": "gomodel:5d88482400000052/5d88482400000115",
+                        "value-type": "IRI"
+                    },
+                    {
+                        "key": "contributor",
+                        "value": "http://orcid.org/0000-0002-1706-4196"
+                    },
+                    {
+                        "key": "date",
+                        "value": "2019-09-25"
+                    }
+                ]
+            }
+        ],
+        "annotations": [
+            {
+                "key": "state",
+                "value": "development"
+            },
+            {
+                "key": "contributor",
+                "value": "http://orcid.org/0000-0002-1706-4196"
+            },
+            {
+                "key": "date",
+                "value": "2019-09-25"
+            },
+            {
+                "key": "title",
+                "value": "enabled by mpk-1 Cele"
+            },
+            {
+                "key": "providedBy",
+                "value": "http://www.wormbase.org"
+            }
+        ]
+    }
+}

--- a/packages/bbop-graph-noctua/src/fixtures/response-gomodel-5d88482400000052-2019-09-25.json
+++ b/packages/bbop-graph-noctua/src/fixtures/response-gomodel-5d88482400000052-2019-09-25.json
@@ -1,4691 +1,4691 @@
 {
-    "packet-id": "137084cc46d74214",
-    "provided-by": [],
-    "is-reasoned": true,
-    "intention": "query",
-    "signal": "rebuild",
-    "message-type": "success",
-    "message": "success",
-    "data": {
-        "modified-p": false,
-        "validation-results": {
-            "is-conformant": false,
-            "owl-validation": {
-                "id": "OWL_REASONER",
-                "is-conformant": true,
-                "tracker": "https://github.com/geneontology/helpdesk/issues",
-                "rule-file": "https://github.com/geneontology/go-ontology"
-            },
-            "shex-validation": {
-                "node-matched-shapes": {
-                    "gomodel:5d88482400000052/5d88482400000088": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000087": [
-                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000101": [
-                        "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000089": [
-                        "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000102": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000105": [
-                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000060": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000084": [
-                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000083": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000061": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000063": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000085": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000117": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000099": [
-                        "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000077": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000076": [
-                        "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000098": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000112": [
-                        "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000079": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000111": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000114": [
-                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000058": [
-                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000113": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000116": [
-                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000115": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000091": [
-                        "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000092": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000073": [
-                        "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000095": [
-                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000094": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000053": [
-                        "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000097": [
-                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000075": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000096": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000107": [
-                        "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000106": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000109": [
-                        "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
-                    ],
-                    "gomodel:5d88482400000052/5d88482400000108": [
-                        "http://purl.obolibrary.org/obo/go/shapes/Evidence"
-                    ]
-                },
-                "is-conformant": false,
-                "tracker": "https://github.com/geneontology/go-shapes/issues",
-                "rule-file": "https://github.com/geneontology/go-shapes/blob/master/shapes/go-cam-shapes.shex",
-                "violations": [
-                    {
-                        "explanations": [
-                            {
-                                "shape": "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction",
-                                "constraints": [
-                                    {
-                                        "object": "gomodel:5d88482400000052/5d88482400000082",
-                                        "property": "RO:0002418",
-                                        "intended-range-shapes": [
-                                            "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
-                                        ]
-                                    }
-                                ]
-                            }
-                        ],
-                        "node": "gomodel:5d88482400000052/5d88482400000080"
-                    },
-                    {
-                        "explanations": [],
-                        "node": "gomodel:5d88482400000052/5d88482400000093"
-                    }
-                ]
-            }
+  "packet-id": "137084cc46d74214",
+  "provided-by": [],
+  "is-reasoned": true,
+  "intention": "query",
+  "signal": "rebuild",
+  "message-type": "success",
+  "message": "success",
+  "data": {
+    "modified-p": false,
+    "validation-results": {
+      "is-conformant": false,
+      "owl-validation": {
+        "id": "OWL_REASONER",
+        "is-conformant": true,
+        "tracker": "https://github.com/geneontology/helpdesk/issues",
+        "rule-file": "https://github.com/geneontology/go-ontology"
+      },
+      "shex-validation": {
+        "node-matched-shapes": {
+          "gomodel:5d88482400000052/5d88482400000088": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000087": [
+            "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+          ],
+          "gomodel:5d88482400000052/5d88482400000101": [
+            "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
+          ],
+          "gomodel:5d88482400000052/5d88482400000089": [
+            "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
+          ],
+          "gomodel:5d88482400000052/5d88482400000102": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000105": [
+            "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+          ],
+          "gomodel:5d88482400000052/5d88482400000060": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000084": [
+            "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+          ],
+          "gomodel:5d88482400000052/5d88482400000083": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000061": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000063": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000085": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000117": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000099": [
+            "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
+          ],
+          "gomodel:5d88482400000052/5d88482400000077": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000076": [
+            "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
+          ],
+          "gomodel:5d88482400000052/5d88482400000098": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000112": [
+            "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
+          ],
+          "gomodel:5d88482400000052/5d88482400000079": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000111": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000114": [
+            "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+          ],
+          "gomodel:5d88482400000052/5d88482400000058": [
+            "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+          ],
+          "gomodel:5d88482400000052/5d88482400000113": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000116": [
+            "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+          ],
+          "gomodel:5d88482400000052/5d88482400000115": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000091": [
+            "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
+          ],
+          "gomodel:5d88482400000052/5d88482400000092": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000073": [
+            "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
+          ],
+          "gomodel:5d88482400000052/5d88482400000095": [
+            "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+          ],
+          "gomodel:5d88482400000052/5d88482400000094": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000053": [
+            "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
+          ],
+          "gomodel:5d88482400000052/5d88482400000097": [
+            "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+          ],
+          "gomodel:5d88482400000052/5d88482400000075": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000096": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000107": [
+            "http://purl.obolibrary.org/obo/go/shapes/CellularComponent"
+          ],
+          "gomodel:5d88482400000052/5d88482400000106": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ],
+          "gomodel:5d88482400000052/5d88482400000109": [
+            "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction"
+          ],
+          "gomodel:5d88482400000052/5d88482400000108": [
+            "http://purl.obolibrary.org/obo/go/shapes/Evidence"
+          ]
         },
-        "id": "gomodel:5d88482400000052",
-        "individuals": [
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000053",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0004674",
-                        "label": "protein serine/threonine kinase activity"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0004672",
-                        "label": "protein kinase activity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000003",
-                        "label": "occurrent"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0016772",
-                        "label": "transferase activity, transferring phosphorus-containing groups"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0016773",
-                        "label": "phosphotransferase activity, alcohol group as acceptor"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0016740",
-                        "label": "transferase activity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0004674",
-                        "label": "protein serine/threonine kinase activity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0016301",
-                        "label": "kinase activity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0140096",
-                        "label": "catalytic activity, acting on a protein"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0003824",
-                        "label": "catalytic activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-24"
-                    }
+        "is-conformant": false,
+        "tracker": "https://github.com/geneontology/go-shapes/issues",
+        "rule-file": "https://github.com/geneontology/go-shapes/blob/master/shapes/go-cam-shapes.shex",
+        "violations": [
+          {
+            "explanations": [
+              {
+                "shape": "http://purl.obolibrary.org/obo/go/shapes/MolecularFunction",
+                "constraints": [
+                  {
+                    "object": "gomodel:5d88482400000052/5d88482400000082",
+                    "property": "RO:0002418",
+                    "intended-range-shapes": [
+                      "http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess"
+                    ]
+                  }
                 ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000054",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00003401",
-                        "label": "mpk-1 Cele"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33582",
-                        "label": "carbon group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33694",
-                        "label": "biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36357",
-                        "label": "polyatomic entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi gene"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33675",
-                        "label": "p-block molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00003401",
-                        "label": "mpk-1 Cele"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33579",
-                        "label": "main group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33839",
-                        "label": "macromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:50860",
-                        "label": "organic molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:23367",
-                        "label": "molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-24"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000058",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005813",
-                        "label": "centrosome"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "GO:0044422",
-                        "label": "organelle part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044424",
-                        "label": "intracellular part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044446",
-                        "label": "intracellular organelle part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0030000",
-                        "label": "biological entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044430",
-                        "label": "cytoskeletal part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044464",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "cellular_component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005813",
-                        "label": "centrosome"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005815",
-                        "label": "microtubule organizing center"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000006",
-                        "label": "material anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000003",
-                        "label": "connected anatomical structure"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000014",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-24"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000060",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:31296532"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-24"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000061",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000015",
-                        "label": "mutant phenotype evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000059",
-                        "label": "experimental phenotypic evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-24"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:1236758"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000063",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-24"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:31296532"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000067",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:78686",
-                        "label": "Delta(4)-dafachronic acid"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36586",
-                        "label": "carbonyl compound"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33595",
-                        "label": "cyclic compound"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36587",
-                        "label": "organic oxo compound"
-                    },
-                    {
-                        "type": "class",
-                        "id": "obo:GOCHE_37527",
-                        "label": "substance with acid role"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33674",
-                        "label": "s-block molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33675",
-                        "label": "p-block molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33832",
-                        "label": "organic cyclic compound"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33635",
-                        "label": "polycyclic compound"
-                    },
-                    {
-                        "type": "class",
-                        "id": "obo:GOCHE_50906",
-                        "label": "substance with role role"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:3992",
-                        "label": "cyclic ketone"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:35341",
-                        "label": "steroid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33285",
-                        "label": "heteroorganic entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:47909",
-                        "label": "3-oxo-Delta(4) steroid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36357",
-                        "label": "polyatomic entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:35789",
-                        "label": "oxo steroid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:25384",
-                        "label": "monocarboxylic acid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24651",
-                        "label": "hydroxides"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:72695",
-                        "label": "organic molecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:23367",
-                        "label": "molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:50401",
-                        "label": "cholestanoid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "obo:GOCHE_48705",
-                        "label": "substance with agonist role"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "obo:GOCHE_24432",
-                        "label": "substance with biological role role"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36962",
-                        "label": "organochalcogen compound"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:37577",
-                        "label": "heteroatomic molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:18059",
-                        "label": "lipid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33575",
-                        "label": "carboxylic acid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36963",
-                        "label": "organooxygen compound"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:51958",
-                        "label": "organic polycyclic compound"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33579",
-                        "label": "main group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:131619",
-                        "label": "C27-steroid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33608",
-                        "label": "hydrogen molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:51689",
-                        "label": "enone"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:51721",
-                        "label": "alpha,beta-unsaturated ketone"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:47788",
-                        "label": "3-oxo steroid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:26764",
-                        "label": "steroid hormone"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:17087",
-                        "label": "ketone"
-                    },
-                    {
-                        "type": "class",
-                        "id": "obo:GOCHE_24621",
-                        "label": "substance with hormone role"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:78686",
-                        "label": "Delta(4)-dafachronic acid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:78840",
-                        "label": "olefinic compound"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:64709",
-                        "label": "organic acid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33582",
-                        "label": "carbon group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "obo:GOCHE_51086",
-                        "label": "substance with chemical role role"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33304",
-                        "label": "chalcogen molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:35605",
-                        "label": "carbon oxoacid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "obo:GOCHE_17891",
-                        "label": "substance with donor role"
-                    },
-                    {
-                        "type": "class",
-                        "id": "obo:GOCHE_52210",
-                        "label": "substance with pharmacological role role"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:47891",
-                        "label": "steroid acid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:50860",
-                        "label": "organic molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "obo:GOCHE_39141",
-                        "label": "substance with Bronsted acid role"
-                    },
-                    {
-                        "type": "class",
-                        "id": "obo:GOCHE_33280",
-                        "label": "substance with molecular messenger role"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:25367",
-                        "label": "molecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24833",
-                        "label": "oxoacid"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:78698",
-                        "label": "dafachronic acids"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:25806",
-                        "label": "oxygen molecular entity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-24"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000073",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005484",
-                        "label": "SNAP receptor activity"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000003",
-                        "label": "occurrent"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005488",
-                        "label": "binding"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005515",
-                        "label": "protein binding"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005484",
-                        "label": "SNAP receptor activity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000074",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00005193",
-                        "label": "srg-36 Cele"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33582",
-                        "label": "carbon group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33694",
-                        "label": "biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36357",
-                        "label": "polyatomic entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi gene"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33675",
-                        "label": "p-block molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33579",
-                        "label": "main group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00005193",
-                        "label": "srg-36 Cele"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33839",
-                        "label": "macromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:50860",
-                        "label": "organic molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:23367",
-                        "label": "molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000075",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:138"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000076",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0023052",
-                        "label": "signaling"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000003",
-                        "label": "occurrent"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0008150",
-                        "label": "Biological Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0023052",
-                        "label": "signaling"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000077",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000015",
-                        "label": "mutant phenotype evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000059",
-                        "label": "experimental phenotypic evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:138"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000078",
-                "type": [
-                    {
-                        "type": "complement",
-                        "filler": {
-                            "type": "class",
-                            "id": "GO:0005886",
-                            "label": "plasma membrane"
-                        }
-                    }
-                ],
-                "inferred-type": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000079",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:139"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000080",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000003",
-                        "label": "occurrent"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000081",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00005194",
-                        "label": "srg-37 Cele"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33582",
-                        "label": "carbon group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33694",
-                        "label": "biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36357",
-                        "label": "polyatomic entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi gene"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33675",
-                        "label": "p-block molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33579",
-                        "label": "main group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00005194",
-                        "label": "srg-37 Cele"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33839",
-                        "label": "macromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:50860",
-                        "label": "organic molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:23367",
-                        "label": "molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000082",
-                "type": [
-                    {
-                        "type": "complement",
-                        "filler": {
-                            "type": "class",
-                            "id": "GO:0071291",
-                            "label": "cellular response to selenium ion"
-                        }
-                    }
-                ],
-                "inferred-type": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000003",
-                        "label": "occurrent"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000083",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000015",
-                        "label": "mutant phenotype evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000059",
-                        "label": "experimental phenotypic evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:141"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000084",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005886",
-                        "label": "plasma membrane"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CARO:0030000",
-                        "label": "biological entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044464",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "cellular_component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005886",
-                        "label": "plasma membrane"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000006",
-                        "label": "material anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000003",
-                        "label": "connected anatomical structure"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000014",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0016020",
-                        "label": "membrane"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000085",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:141"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000086",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00004053",
-                        "label": "tank-1 Cele"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33582",
-                        "label": "carbon group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33694",
-                        "label": "biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36357",
-                        "label": "polyatomic entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi gene"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33675",
-                        "label": "p-block molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33579",
-                        "label": "main group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00004053",
-                        "label": "tank-1 Cele"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33839",
-                        "label": "macromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:50860",
-                        "label": "organic molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:23367",
-                        "label": "molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000087",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005829",
-                        "label": "cytosol"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "GO:0044444",
-                        "label": "cytoplasmic part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044424",
-                        "label": "intracellular part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0030000",
-                        "label": "biological entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044464",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "cellular_component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000006",
-                        "label": "material anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000003",
-                        "label": "connected anatomical structure"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000014",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005829",
-                        "label": "cytosol"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000088",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:153"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000089",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000003",
-                        "label": "occurrent"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000090",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00003168",
-                        "label": "mec-4 Cele"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33582",
-                        "label": "carbon group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33694",
-                        "label": "biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36357",
-                        "label": "polyatomic entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi gene"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33675",
-                        "label": "p-block molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00003168",
-                        "label": "mec-4 Cele"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33579",
-                        "label": "main group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33839",
-                        "label": "macromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:50860",
-                        "label": "organic molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:23367",
-                        "label": "molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000091",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0070656",
-                        "label": "mechanoreceptor differentiation involved in mechanosensory epithelium regeneration"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "GO:0070656",
-                        "label": "mechanoreceptor differentiation involved in mechanosensory epithelium regeneration"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0048869",
-                        "label": "cellular developmental process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0009987",
-                        "label": "cellular process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000003",
-                        "label": "occurrent"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0032502",
-                        "label": "developmental process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0042490",
-                        "label": "mechanoreceptor differentiation"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0008150",
-                        "label": "Biological Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0030182",
-                        "label": "neuron differentiation"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0030154",
-                        "label": "cell differentiation"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000092",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000015",
-                        "label": "mutant phenotype evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000059",
-                        "label": "experimental phenotypic evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:219"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000093",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005886",
-                        "label": "plasma membrane"
-                    }
-                ],
-                "inferred-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005886",
-                        "label": "plasma membrane"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0097458",
-                        "label": "neuron part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044441",
-                        "label": "ciliary part"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "GO:0044422",
-                        "label": "organelle part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0120038",
-                        "label": "plasma membrane bounded cell projection part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0030000",
-                        "label": "biological entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044463",
-                        "label": "cell projection part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044441",
-                        "label": "ciliary part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044464",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "cellular_component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005886",
-                        "label": "plasma membrane"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000006",
-                        "label": "material anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000003",
-                        "label": "connected anatomical structure"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000014",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0097458",
-                        "label": "neuron part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0016020",
-                        "label": "membrane"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000094",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:219"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000095",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "WBbt:0003679",
-                        "label": "neuron"
-                    }
-                ],
-                "inferred-type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001062",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WBbt:0003679",
-                        "label": "neuron"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000540",
-                        "label": "neuron"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CARO:0030000",
-                        "label": "biological entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0002319",
-                        "label": "neural cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001062",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WBbt:0003679",
-                        "label": "neuron"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005623",
-                        "label": "cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000255",
-                        "label": "eukaryotic cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000211",
-                        "label": "electrically active cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000006",
-                        "label": "material anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000003",
-                        "label": "connected anatomical structure"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0002371",
-                        "label": "somatic cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WBbt:0000100",
-                        "label": "C. elegans Cell and Anatomy"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000393",
-                        "label": "electrically responsive cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000404",
-                        "label": "electrically signaling cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000548",
-                        "label": "animal cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WBbt:0004017",
-                        "label": "Cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "cellular_component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000003",
-                        "label": "native cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000000",
-                        "label": "cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000540",
-                        "label": "neuron"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000096",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:219"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000097",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005929",
-                        "label": "cilium"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "GO:0043226",
-                        "label": "organelle"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0042995",
-                        "label": "cell projection"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0120025",
-                        "label": "plasma membrane bounded cell projection"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0030000",
-                        "label": "biological entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044464",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "cellular_component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000006",
-                        "label": "material anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000003",
-                        "label": "connected anatomical structure"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000014",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005929",
-                        "label": "cilium"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000098",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:223"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000099",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000003",
-                        "label": "occurrent"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000100",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00000002",
-                        "label": "aat-1 Cele"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33582",
-                        "label": "carbon group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33694",
-                        "label": "biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36357",
-                        "label": "polyatomic entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi gene"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33675",
-                        "label": "p-block molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00000002",
-                        "label": "aat-1 Cele"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33579",
-                        "label": "main group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33839",
-                        "label": "macromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:50860",
-                        "label": "organic molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:23367",
-                        "label": "molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000101",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0010267",
-                        "label": "production of ta-siRNAs involved in RNA interference"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "GO:0044238",
-                        "label": "primary metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044237",
-                        "label": "cellular metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0071704",
-                        "label": "organic substance metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0008152",
-                        "label": "metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:1901360",
-                        "label": "organic cyclic compound metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0070918",
-                        "label": "production of small RNA involved in gene silencing by RNA"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0008150",
-                        "label": "Biological Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0046483",
-                        "label": "heterocycle metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0006396",
-                        "label": "RNA processing"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0009987",
-                        "label": "cellular process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000003",
-                        "label": "occurrent"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0030422",
-                        "label": "production of siRNA involved in RNA interference"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0010267",
-                        "label": "production of ta-siRNAs involved in RNA interference"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0043170",
-                        "label": "macromolecule metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0006139",
-                        "label": "nucleobase-containing compound metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0016070",
-                        "label": "RNA metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0090304",
-                        "label": "nucleic acid metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0006725",
-                        "label": "cellular aromatic compound metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0031050",
-                        "label": "dsRNA processing"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0034641",
-                        "label": "cellular nitrogen compound metabolic process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0006807",
-                        "label": "nitrogen compound metabolic process"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000102",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000015",
-                        "label": "mutant phenotype evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000059",
-                        "label": "experimental phenotypic evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:1236758"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000104",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00000003",
-                        "label": "aat-2 Cele"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33582",
-                        "label": "carbon group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33694",
-                        "label": "biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36357",
-                        "label": "polyatomic entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi gene"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00000003",
-                        "label": "aat-2 Cele"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33675",
-                        "label": "p-block molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33579",
-                        "label": "main group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33839",
-                        "label": "macromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:50860",
-                        "label": "organic molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:23367",
-                        "label": "molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000105",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005886",
-                        "label": "plasma membrane"
-                    }
-                ],
-                "inferred-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005886",
-                        "label": "plasma membrane"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044441",
-                        "label": "ciliary part"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "GO:0044422",
-                        "label": "organelle part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0120038",
-                        "label": "plasma membrane bounded cell projection part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0030000",
-                        "label": "biological entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044463",
-                        "label": "cell projection part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044441",
-                        "label": "ciliary part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044464",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "cellular_component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005886",
-                        "label": "plasma membrane"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000006",
-                        "label": "material anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000003",
-                        "label": "connected anatomical structure"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000014",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0016020",
-                        "label": "membrane"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000106",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:138"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000107",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005929",
-                        "label": "cilium"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "GO:0043226",
-                        "label": "organelle"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0042995",
-                        "label": "cell projection"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0120025",
-                        "label": "plasma membrane bounded cell projection"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0030000",
-                        "label": "biological entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044464",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "cellular_component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000006",
-                        "label": "material anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000003",
-                        "label": "connected anatomical structure"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000014",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005929",
-                        "label": "cilium"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000108",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:138"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000109",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0005215",
-                        "label": "transporter activity"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000003",
-                        "label": "occurrent"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005215",
-                        "label": "transporter activity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0003674",
-                        "label": "Molecular Function"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000110",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00000004",
-                        "label": "aat-3 Cele"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33582",
-                        "label": "carbon group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33694",
-                        "label": "biomacromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:36357",
-                        "label": "polyatomic entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33695",
-                        "label": "chebi gene"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WB:WBGene00000004",
-                        "label": "aat-3 Cele"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33675",
-                        "label": "p-block molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33579",
-                        "label": "main group molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:33839",
-                        "label": "macromolecule"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:50860",
-                        "label": "organic molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:24431",
-                        "label": "chemical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CHEBI:23367",
-                        "label": "molecular entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000111",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:138"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000112",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:1900285",
-                        "label": "regulation of cellotriose transport"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "BFO:0000015",
-                        "label": "Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000003",
-                        "label": "occurrent"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0050789",
-                        "label": "regulation of biological process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0032879",
-                        "label": "regulation of localization"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0008150",
-                        "label": "Biological Process"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0065007",
-                        "label": "biological regulation"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:1900285",
-                        "label": "regulation of cellotriose transport"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0051049",
-                        "label": "regulation of transport"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000113",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000315",
-                        "label": "mutant phenotype evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000015",
-                        "label": "mutant phenotype evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000059",
-                        "label": "experimental phenotypic evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "source",
-                        "value": "PMID:1236758"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000114",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0098590",
-                        "label": "plasma membrane region"
-                    }
-                ],
-                "inferred-type": [
-                    {
-                        "type": "class",
-                        "id": "GO:0098590",
-                        "label": "plasma membrane region"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0097458",
-                        "label": "neuron part"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "GO:0044425",
-                        "label": "membrane part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044459",
-                        "label": "plasma membrane part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0030000",
-                        "label": "biological entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0044464",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0098590",
-                        "label": "plasma membrane region"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "cellular_component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000006",
-                        "label": "material anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000003",
-                        "label": "connected anatomical structure"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000014",
-                        "label": "cell part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0097458",
-                        "label": "neuron part"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0016020",
-                        "label": "membrane"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000115",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:138"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000116",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "WBbt:0005394",
-                        "label": "amphid neuron"
-                    }
-                ],
-                "inferred-type": [
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001062",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000540",
-                        "label": "neuron"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WBbt:0005394",
-                        "label": "amphid neuron"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "CARO:0030000",
-                        "label": "biological entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000000",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0002319",
-                        "label": "neural cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "UBERON:0001062",
-                        "label": "anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WBbt:0003679",
-                        "label": "neuron"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005623",
-                        "label": "cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000255",
-                        "label": "eukaryotic cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000211",
-                        "label": "electrically active cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000006",
-                        "label": "material anatomical entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WBbt:0005394",
-                        "label": "amphid neuron"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CARO:0000003",
-                        "label": "connected anatomical structure"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0002371",
-                        "label": "somatic cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WBbt:0000100",
-                        "label": "C. elegans Cell and Anatomy"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000393",
-                        "label": "electrically responsive cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000030",
-                        "label": "object"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WBbt:0006816",
-                        "label": "ciliated neuron"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000004",
-                        "label": "independent continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000404",
-                        "label": "electrically signaling cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000002",
-                        "label": "continuant"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000548",
-                        "label": "animal cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "WBbt:0004017",
-                        "label": "Cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000001",
-                        "label": "entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "GO:0005575",
-                        "label": "cellular_component"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000003",
-                        "label": "native cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "BFO:0000040",
-                        "label": "material entity"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000000",
-                        "label": "cell"
-                    },
-                    {
-                        "type": "class",
-                        "id": "CL:0000540",
-                        "label": "neuron"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "id": "gomodel:5d88482400000052/5d88482400000117",
-                "type": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    }
-                ],
-                "inferred-type-with-all": [
-                    {
-                        "type": "class",
-                        "id": "ECO:0000000",
-                        "label": "evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000002",
-                        "label": "direct assay evidence"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000314",
-                        "label": "direct assay evidence used in manual assertion"
-                    },
-                    {
-                        "type": "class",
-                        "id": "ECO:0000006",
-                        "label": "experimental evidence"
-                    }
-                ],
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    },
-                    {
-                        "key": "source",
-                        "value": "PMID:138"
-                    }
-                ]
-            }
+              }
+            ],
+            "node": "gomodel:5d88482400000052/5d88482400000080"
+          },
+          {
+            "explanations": [],
+            "node": "gomodel:5d88482400000052/5d88482400000093"
+          }
+        ]
+      }
+    },
+    "id": "gomodel:5d88482400000052",
+    "individuals": [
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000053",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0004674",
+            "label": "protein serine/threonine kinase activity"
+          }
         ],
-        "facts": [
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000082",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:5d88482400000052/5d88482400000084",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000085",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000073",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:5d88482400000052/5d88482400000074",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000075",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000053",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:5d88482400000052/5d88482400000058",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000063",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-24"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000105",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:5d88482400000052/5d88482400000107",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000108",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000089",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:5d88482400000052/5d88482400000090",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000104",
-                "property": "RO:0001025",
-                "property-label": "located_in",
-                "object": "gomodel:5d88482400000052/5d88482400000105",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000106",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000073",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:5d88482400000052/5d88482400000076",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000077",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000073",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:5d88482400000052/5d88482400000078",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000079",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000114",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:5d88482400000052/5d88482400000116",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000117",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000086",
-                "property": "RO:0001025",
-                "property-label": "located_in",
-                "object": "gomodel:5d88482400000052/5d88482400000087",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000088",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000091",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:5d88482400000052/5d88482400000093",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000094",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000080",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:5d88482400000052/5d88482400000081",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000109",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:5d88482400000052/5d88482400000110",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000111",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000099",
-                "property": "RO:0002418",
-                "property-label": "causally upstream of or within",
-                "object": "gomodel:5d88482400000052/5d88482400000101",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000102",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000093",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:5d88482400000052/5d88482400000097",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000098",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000093",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:5d88482400000052/5d88482400000095",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000096",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000080",
-                "property": "RO:0002418",
-                "property-label": "causally upstream of or within",
-                "object": "gomodel:5d88482400000052/5d88482400000082",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000083",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000053",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:5d88482400000052/5d88482400000054",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000060",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000061",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-24"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000109",
-                "property": "BFO:0000050",
-                "property-label": "part of",
-                "object": "gomodel:5d88482400000052/5d88482400000112",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000113",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000089",
-                "property": "RO:0002418",
-                "property-label": "causally upstream of or within",
-                "object": "gomodel:5d88482400000052/5d88482400000091",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000092",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000099",
-                "property": "RO:0002333",
-                "property-label": "enabled by",
-                "object": "gomodel:5d88482400000052/5d88482400000100",
-                "annotations": [
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            },
-            {
-                "subject": "gomodel:5d88482400000052/5d88482400000109",
-                "property": "BFO:0000066",
-                "property-label": "occurs in",
-                "object": "gomodel:5d88482400000052/5d88482400000114",
-                "annotations": [
-                    {
-                        "key": "evidence",
-                        "value": "gomodel:5d88482400000052/5d88482400000115",
-                        "value-type": "IRI"
-                    },
-                    {
-                        "key": "contributor",
-                        "value": "http://orcid.org/0000-0002-1706-4196"
-                    },
-                    {
-                        "key": "date",
-                        "value": "2019-09-25"
-                    }
-                ]
-            }
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0004672",
+            "label": "protein kinase activity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016772",
+            "label": "transferase activity, transferring phosphorus-containing groups"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016773",
+            "label": "phosphotransferase activity, alcohol group as acceptor"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016740",
+            "label": "transferase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0004674",
+            "label": "protein serine/threonine kinase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016301",
+            "label": "kinase activity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          },
+          {
+            "type": "class",
+            "id": "GO:0140096",
+            "label": "catalytic activity, acting on a protein"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003824",
+            "label": "catalytic activity"
+          }
         ],
         "annotations": [
-            {
-                "key": "state",
-                "value": "development"
-            },
-            {
-                "key": "contributor",
-                "value": "http://orcid.org/0000-0002-1706-4196"
-            },
-            {
-                "key": "date",
-                "value": "2019-09-25"
-            },
-            {
-                "key": "title",
-                "value": "enabled by mpk-1 Cele"
-            },
-            {
-                "key": "providedBy",
-                "value": "http://www.wormbase.org"
-            }
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-24"
+          }
         ]
-    }
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000054",
+        "type": [
+          {
+            "type": "class",
+            "id": "WB:WBGene00003401",
+            "label": "mpk-1 Cele"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "WB:WBGene00003401",
+            "label": "mpk-1 Cele"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-24"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000058",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005813",
+            "label": "centrosome"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044424",
+            "label": "intracellular part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044446",
+            "label": "intracellular organelle part"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044430",
+            "label": "cytoskeletal part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005813",
+            "label": "centrosome"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005815",
+            "label": "microtubule organizing center"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-24"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000060",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:31296532"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-24"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000061",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000015",
+            "label": "mutant phenotype evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000059",
+            "label": "experimental phenotypic evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-24"
+          },
+          {
+            "key": "source",
+            "value": "PMID:1236758"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000063",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-24"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "source",
+            "value": "PMID:31296532"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000067",
+        "type": [
+          {
+            "type": "class",
+            "id": "CHEBI:78686",
+            "label": "Delta(4)-dafachronic acid"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:36586",
+            "label": "carbonyl compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33595",
+            "label": "cyclic compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36587",
+            "label": "organic oxo compound"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_37527",
+            "label": "substance with acid role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33674",
+            "label": "s-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33832",
+            "label": "organic cyclic compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33635",
+            "label": "polycyclic compound"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:3992",
+            "label": "cyclic ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:35341",
+            "label": "steroid"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:47909",
+            "label": "3-oxo-Delta(4) steroid"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:35789",
+            "label": "oxo steroid"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25384",
+            "label": "monocarboxylic acid"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24651",
+            "label": "hydroxides"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50401",
+            "label": "cholestanoid"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48705",
+            "label": "substance with agonist role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:18059",
+            "label": "lipid"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33575",
+            "label": "carboxylic acid"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51958",
+            "label": "organic polycyclic compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:131619",
+            "label": "C27-steroid"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33608",
+            "label": "hydrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51689",
+            "label": "enone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51721",
+            "label": "alpha,beta-unsaturated ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:47788",
+            "label": "3-oxo steroid"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26764",
+            "label": "steroid hormone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:17087",
+            "label": "ketone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24621",
+            "label": "substance with hormone role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78686",
+            "label": "Delta(4)-dafachronic acid"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78840",
+            "label": "olefinic compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:64709",
+            "label": "organic acid"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:35605",
+            "label": "carbon oxoacid"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_17891",
+            "label": "substance with donor role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52210",
+            "label": "substance with pharmacological role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:47891",
+            "label": "steroid acid"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39141",
+            "label": "substance with Bronsted acid role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33280",
+            "label": "substance with molecular messenger role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24833",
+            "label": "oxoacid"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78698",
+            "label": "dafachronic acids"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-24"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000073",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005484",
+            "label": "SNAP receptor activity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005488",
+            "label": "binding"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005515",
+            "label": "protein binding"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005484",
+            "label": "SNAP receptor activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000074",
+        "type": [
+          {
+            "type": "class",
+            "id": "WB:WBGene00005193",
+            "label": "srg-36 Cele"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "WB:WBGene00005193",
+            "label": "srg-36 Cele"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000075",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "source",
+            "value": "PMID:138"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000076",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0023052",
+            "label": "signaling"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008150",
+            "label": "Biological Process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0023052",
+            "label": "signaling"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000077",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000015",
+            "label": "mutant phenotype evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000059",
+            "label": "experimental phenotypic evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:138"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000078",
+        "type": [
+          {
+            "type": "complement",
+            "filler": {
+              "type": "class",
+              "id": "GO:0005886",
+              "label": "plasma membrane"
+            }
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000079",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "source",
+            "value": "PMID:139"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000080",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000081",
+        "type": [
+          {
+            "type": "class",
+            "id": "WB:WBGene00005194",
+            "label": "srg-37 Cele"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "WB:WBGene00005194",
+            "label": "srg-37 Cele"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000082",
+        "type": [
+          {
+            "type": "complement",
+            "filler": {
+              "type": "class",
+              "id": "GO:0071291",
+              "label": "cellular response to selenium ion"
+            }
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000083",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000015",
+            "label": "mutant phenotype evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000059",
+            "label": "experimental phenotypic evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "source",
+            "value": "PMID:141"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000084",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005886",
+            "label": "plasma membrane"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005886",
+            "label": "plasma membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000085",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:141"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000086",
+        "type": [
+          {
+            "type": "class",
+            "id": "WB:WBGene00004053",
+            "label": "tank-1 Cele"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "WB:WBGene00004053",
+            "label": "tank-1 Cele"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000087",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005829",
+            "label": "cytosol"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044444",
+            "label": "cytoplasmic part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044424",
+            "label": "intracellular part"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005829",
+            "label": "cytosol"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000088",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:153"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000089",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000090",
+        "type": [
+          {
+            "type": "class",
+            "id": "WB:WBGene00003168",
+            "label": "mec-4 Cele"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "WB:WBGene00003168",
+            "label": "mec-4 Cele"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000091",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0070656",
+            "label": "mechanoreceptor differentiation involved in mechanosensory epithelium regeneration"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0070656",
+            "label": "mechanoreceptor differentiation involved in mechanosensory epithelium regeneration"
+          },
+          {
+            "type": "class",
+            "id": "GO:0048869",
+            "label": "cellular developmental process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0009987",
+            "label": "cellular process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0032502",
+            "label": "developmental process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0042490",
+            "label": "mechanoreceptor differentiation"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008150",
+            "label": "Biological Process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0030182",
+            "label": "neuron differentiation"
+          },
+          {
+            "type": "class",
+            "id": "GO:0030154",
+            "label": "cell differentiation"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000092",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000015",
+            "label": "mutant phenotype evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000059",
+            "label": "experimental phenotypic evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "source",
+            "value": "PMID:219"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000093",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005886",
+            "label": "plasma membrane"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "GO:0005886",
+            "label": "plasma membrane"
+          },
+          {
+            "type": "class",
+            "id": "GO:0097458",
+            "label": "neuron part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044441",
+            "label": "ciliary part"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0120038",
+            "label": "plasma membrane bounded cell projection part"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044463",
+            "label": "cell projection part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044441",
+            "label": "ciliary part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005886",
+            "label": "plasma membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0097458",
+            "label": "neuron part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000094",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "source",
+            "value": "PMID:219"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000095",
+        "type": [
+          {
+            "type": "class",
+            "id": "WBbt:0003679",
+            "label": "neuron"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001062",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "WBbt:0003679",
+            "label": "neuron"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000540",
+            "label": "neuron"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CL:0002319",
+            "label": "neural cell"
+          },
+          {
+            "type": "class",
+            "id": "UBERON:0001062",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "WBbt:0003679",
+            "label": "neuron"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005623",
+            "label": "cell"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000255",
+            "label": "eukaryotic cell"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000211",
+            "label": "electrically active cell"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CL:0002371",
+            "label": "somatic cell"
+          },
+          {
+            "type": "class",
+            "id": "WBbt:0000100",
+            "label": "C. elegans Cell and Anatomy"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000393",
+            "label": "electrically responsive cell"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000404",
+            "label": "electrically signaling cell"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000548",
+            "label": "animal cell"
+          },
+          {
+            "type": "class",
+            "id": "WBbt:0004017",
+            "label": "Cell"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000003",
+            "label": "native cell"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000000",
+            "label": "cell"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000540",
+            "label": "neuron"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000096",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:219"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000097",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005929",
+            "label": "cilium"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0043226",
+            "label": "organelle"
+          },
+          {
+            "type": "class",
+            "id": "GO:0042995",
+            "label": "cell projection"
+          },
+          {
+            "type": "class",
+            "id": "GO:0120025",
+            "label": "plasma membrane bounded cell projection"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005929",
+            "label": "cilium"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000098",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "source",
+            "value": "PMID:223"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000099",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000100",
+        "type": [
+          {
+            "type": "class",
+            "id": "WB:WBGene00000002",
+            "label": "aat-1 Cele"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "WB:WBGene00000002",
+            "label": "aat-1 Cele"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000101",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0010267",
+            "label": "production of ta-siRNAs involved in RNA interference"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044238",
+            "label": "primary metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044237",
+            "label": "cellular metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0071704",
+            "label": "organic substance metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008152",
+            "label": "metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:1901360",
+            "label": "organic cyclic compound metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0070918",
+            "label": "production of small RNA involved in gene silencing by RNA"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008150",
+            "label": "Biological Process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0046483",
+            "label": "heterocycle metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0006396",
+            "label": "RNA processing"
+          },
+          {
+            "type": "class",
+            "id": "GO:0009987",
+            "label": "cellular process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0030422",
+            "label": "production of siRNA involved in RNA interference"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0010267",
+            "label": "production of ta-siRNAs involved in RNA interference"
+          },
+          {
+            "type": "class",
+            "id": "GO:0043170",
+            "label": "macromolecule metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0006139",
+            "label": "nucleobase-containing compound metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016070",
+            "label": "RNA metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0090304",
+            "label": "nucleic acid metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0006725",
+            "label": "cellular aromatic compound metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0031050",
+            "label": "dsRNA processing"
+          },
+          {
+            "type": "class",
+            "id": "GO:0034641",
+            "label": "cellular nitrogen compound metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0006807",
+            "label": "nitrogen compound metabolic process"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000102",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000015",
+            "label": "mutant phenotype evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000059",
+            "label": "experimental phenotypic evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "source",
+            "value": "PMID:1236758"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000104",
+        "type": [
+          {
+            "type": "class",
+            "id": "WB:WBGene00000003",
+            "label": "aat-2 Cele"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "WB:WBGene00000003",
+            "label": "aat-2 Cele"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000105",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005886",
+            "label": "plasma membrane"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "GO:0005886",
+            "label": "plasma membrane"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044441",
+            "label": "ciliary part"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0120038",
+            "label": "plasma membrane bounded cell projection part"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044463",
+            "label": "cell projection part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044441",
+            "label": "ciliary part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005886",
+            "label": "plasma membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000106",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:138"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000107",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005929",
+            "label": "cilium"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0043226",
+            "label": "organelle"
+          },
+          {
+            "type": "class",
+            "id": "GO:0042995",
+            "label": "cell projection"
+          },
+          {
+            "type": "class",
+            "id": "GO:0120025",
+            "label": "plasma membrane bounded cell projection"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005929",
+            "label": "cilium"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000108",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "source",
+            "value": "PMID:138"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000109",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005215",
+            "label": "transporter activity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005215",
+            "label": "transporter activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000110",
+        "type": [
+          {
+            "type": "class",
+            "id": "WB:WBGene00000004",
+            "label": "aat-3 Cele"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "WB:WBGene00000004",
+            "label": "aat-3 Cele"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000111",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "source",
+            "value": "PMID:138"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000112",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:1900285",
+            "label": "regulation of cellotriose transport"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0050789",
+            "label": "regulation of biological process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0032879",
+            "label": "regulation of localization"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008150",
+            "label": "Biological Process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0065007",
+            "label": "biological regulation"
+          },
+          {
+            "type": "class",
+            "id": "GO:1900285",
+            "label": "regulation of cellotriose transport"
+          },
+          {
+            "type": "class",
+            "id": "GO:0051049",
+            "label": "regulation of transport"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000113",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000315",
+            "label": "mutant phenotype evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000015",
+            "label": "mutant phenotype evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000059",
+            "label": "experimental phenotypic evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "PMID:1236758"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000114",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0098590",
+            "label": "plasma membrane region"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "GO:0098590",
+            "label": "plasma membrane region"
+          },
+          {
+            "type": "class",
+            "id": "GO:0097458",
+            "label": "neuron part"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044425",
+            "label": "membrane part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044459",
+            "label": "plasma membrane part"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "GO:0098590",
+            "label": "plasma membrane region"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0097458",
+            "label": "neuron part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000115",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "source",
+            "value": "PMID:138"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000116",
+        "type": [
+          {
+            "type": "class",
+            "id": "WBbt:0005394",
+            "label": "amphid neuron"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "UBERON:0001062",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000540",
+            "label": "neuron"
+          },
+          {
+            "type": "class",
+            "id": "WBbt:0005394",
+            "label": "amphid neuron"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CL:0002319",
+            "label": "neural cell"
+          },
+          {
+            "type": "class",
+            "id": "UBERON:0001062",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "WBbt:0003679",
+            "label": "neuron"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005623",
+            "label": "cell"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000255",
+            "label": "eukaryotic cell"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000211",
+            "label": "electrically active cell"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "WBbt:0005394",
+            "label": "amphid neuron"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CL:0002371",
+            "label": "somatic cell"
+          },
+          {
+            "type": "class",
+            "id": "WBbt:0000100",
+            "label": "C. elegans Cell and Anatomy"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000393",
+            "label": "electrically responsive cell"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "WBbt:0006816",
+            "label": "ciliated neuron"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000404",
+            "label": "electrically signaling cell"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000548",
+            "label": "animal cell"
+          },
+          {
+            "type": "class",
+            "id": "WBbt:0004017",
+            "label": "Cell"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000003",
+            "label": "native cell"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000000",
+            "label": "cell"
+          },
+          {
+            "type": "class",
+            "id": "CL:0000540",
+            "label": "neuron"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:5d88482400000052/5d88482400000117",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000002",
+            "label": "direct assay evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000314",
+            "label": "direct assay evidence used in manual assertion"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000006",
+            "label": "experimental evidence"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          },
+          {
+            "key": "source",
+            "value": "PMID:138"
+          }
+        ]
+      }
+    ],
+    "facts": [
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000082",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:5d88482400000052/5d88482400000084",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000085",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000073",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:5d88482400000052/5d88482400000074",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000075",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000053",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:5d88482400000052/5d88482400000058",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000063",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-24"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000105",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:5d88482400000052/5d88482400000107",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000108",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000089",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:5d88482400000052/5d88482400000090",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000104",
+        "property": "RO:0001025",
+        "property-label": "located_in",
+        "object": "gomodel:5d88482400000052/5d88482400000105",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000106",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000073",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:5d88482400000052/5d88482400000076",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000077",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000073",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:5d88482400000052/5d88482400000078",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000079",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000114",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:5d88482400000052/5d88482400000116",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000117",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000086",
+        "property": "RO:0001025",
+        "property-label": "located_in",
+        "object": "gomodel:5d88482400000052/5d88482400000087",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000088",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000091",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:5d88482400000052/5d88482400000093",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000094",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000080",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:5d88482400000052/5d88482400000081",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000109",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:5d88482400000052/5d88482400000110",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000111",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000099",
+        "property": "RO:0002418",
+        "property-label": "causally upstream of or within",
+        "object": "gomodel:5d88482400000052/5d88482400000101",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000102",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000093",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:5d88482400000052/5d88482400000097",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000098",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000093",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:5d88482400000052/5d88482400000095",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000096",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000080",
+        "property": "RO:0002418",
+        "property-label": "causally upstream of or within",
+        "object": "gomodel:5d88482400000052/5d88482400000082",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000083",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000053",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:5d88482400000052/5d88482400000054",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000060",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000061",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-24"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000109",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:5d88482400000052/5d88482400000112",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000113",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000089",
+        "property": "RO:0002418",
+        "property-label": "causally upstream of or within",
+        "object": "gomodel:5d88482400000052/5d88482400000091",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000092",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000099",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:5d88482400000052/5d88482400000100",
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:5d88482400000052/5d88482400000109",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:5d88482400000052/5d88482400000114",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:5d88482400000052/5d88482400000115",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "http://orcid.org/0000-0002-1706-4196"
+          },
+          {
+            "key": "date",
+            "value": "2019-09-25"
+          }
+        ]
+      }
+    ],
+    "annotations": [
+      {
+        "key": "state",
+        "value": "development"
+      },
+      {
+        "key": "contributor",
+        "value": "http://orcid.org/0000-0002-1706-4196"
+      },
+      {
+        "key": "date",
+        "value": "2019-09-25"
+      },
+      {
+        "key": "title",
+        "value": "enabled by mpk-1 Cele"
+      },
+      {
+        "key": "providedBy",
+        "value": "http://www.wormbase.org"
+      }
+    ]
+  }
 }

--- a/packages/bbop-graph-noctua/src/fixtures/response-gomodel-R-HSA-159740-2019-09-26.json
+++ b/packages/bbop-graph-noctua/src/fixtures/response-gomodel-R-HSA-159740-2019-09-26.json
@@ -1,0 +1,28286 @@
+{
+  "packet-id": "18d33372bed80341",
+  "provided-by": [],
+  "is-reasoned": true,
+  "intention": "query",
+  "signal": "rebuild",
+  "message-type": "success",
+  "message": "success",
+  "data": {
+    "modified-p": false,
+    "id": "gomodel:R-HSA-159740",
+    "individuals": [
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159752",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "obo:GOCHE_37527",
+            "label": "substance with acid role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33674",
+            "label": "s-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36902",
+            "label": "chalcogen hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33242",
+            "label": "inorganic hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24651",
+            "label": "hydroxides"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:52625",
+            "label": "inorganic hydroxy compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33692",
+            "label": "hydrides"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33693",
+            "label": "oxygen hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48360",
+            "label": "substance with amphiprotic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33608",
+            "label": "hydrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48354",
+            "label": "substance with polar solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48359",
+            "label": "substance with protophilic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37176",
+            "label": "mononuclear parent hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48356",
+            "label": "substance with protic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15377",
+            "label": "water"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_17891",
+            "label": "substance with donor role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39141",
+            "label": "substance with Bronsted acid role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule141",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "H2O"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159761",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "obo:GOCHE_37527",
+            "label": "substance with acid role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33674",
+            "label": "s-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36902",
+            "label": "chalcogen hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33242",
+            "label": "inorganic hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24651",
+            "label": "hydroxides"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:52625",
+            "label": "inorganic hydroxy compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33692",
+            "label": "hydrides"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33693",
+            "label": "oxygen hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48360",
+            "label": "substance with amphiprotic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33608",
+            "label": "hydrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48354",
+            "label": "substance with polar solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48359",
+            "label": "substance with protophilic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37176",
+            "label": "mononuclear parent hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48356",
+            "label": "substance with protic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15377",
+            "label": "water"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_17891",
+            "label": "substance with donor role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39141",
+            "label": "substance with Bronsted acid role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule141",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "H2O"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159795",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "obo:GOCHE_37527",
+            "label": "substance with acid role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33674",
+            "label": "s-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36902",
+            "label": "chalcogen hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33242",
+            "label": "inorganic hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24651",
+            "label": "hydroxides"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:52625",
+            "label": "inorganic hydroxy compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33692",
+            "label": "hydrides"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33693",
+            "label": "oxygen hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48360",
+            "label": "substance with amphiprotic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33608",
+            "label": "hydrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48354",
+            "label": "substance with polar solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48359",
+            "label": "substance with protophilic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37176",
+            "label": "mononuclear parent hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48356",
+            "label": "substance with protic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15377",
+            "label": "water"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_17891",
+            "label": "substance with donor role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39141",
+            "label": "substance with Bronsted acid role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule141",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "H2O"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159803",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "obo:GOCHE_37527",
+            "label": "substance with acid role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33674",
+            "label": "s-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36902",
+            "label": "chalcogen hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33242",
+            "label": "inorganic hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24651",
+            "label": "hydroxides"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:52625",
+            "label": "inorganic hydroxy compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33692",
+            "label": "hydrides"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33693",
+            "label": "oxygen hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48360",
+            "label": "substance with amphiprotic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33608",
+            "label": "hydrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48354",
+            "label": "substance with polar solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48359",
+            "label": "substance with protophilic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37176",
+            "label": "mononuclear parent hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48356",
+            "label": "substance with protic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15377",
+            "label": "water"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_17891",
+            "label": "substance with donor role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39141",
+            "label": "substance with Bronsted acid role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "H2O"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule141",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159819",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "obo:GOCHE_37527",
+            "label": "substance with acid role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33674",
+            "label": "s-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36902",
+            "label": "chalcogen hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33242",
+            "label": "inorganic hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24651",
+            "label": "hydroxides"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:52625",
+            "label": "inorganic hydroxy compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33692",
+            "label": "hydrides"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33693",
+            "label": "oxygen hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48360",
+            "label": "substance with amphiprotic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33608",
+            "label": "hydrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48354",
+            "label": "substance with polar solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48359",
+            "label": "substance with protophilic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37176",
+            "label": "mononuclear parent hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48356",
+            "label": "substance with protic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15377",
+            "label": "water"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_17891",
+            "label": "substance with donor role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39141",
+            "label": "substance with Bronsted acid role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "H2O"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule141",
+            "value-type": "IRI"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159826",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "obo:GOCHE_37527",
+            "label": "substance with acid role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33674",
+            "label": "s-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36902",
+            "label": "chalcogen hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33242",
+            "label": "inorganic hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24651",
+            "label": "hydroxides"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:52625",
+            "label": "inorganic hydroxy compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33692",
+            "label": "hydrides"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33693",
+            "label": "oxygen hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48360",
+            "label": "substance with amphiprotic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33608",
+            "label": "hydrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48354",
+            "label": "substance with polar solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48359",
+            "label": "substance with protophilic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37176",
+            "label": "mononuclear parent hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48356",
+            "label": "substance with protic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15377",
+            "label": "water"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_17891",
+            "label": "substance with donor role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39141",
+            "label": "substance with Bronsted acid role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "H2O"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule141",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-163810",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "obo:GOCHE_37527",
+            "label": "substance with acid role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33674",
+            "label": "s-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36902",
+            "label": "chalcogen hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33242",
+            "label": "inorganic hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24651",
+            "label": "hydroxides"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:52625",
+            "label": "inorganic hydroxy compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33692",
+            "label": "hydrides"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33693",
+            "label": "oxygen hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48360",
+            "label": "substance with amphiprotic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33608",
+            "label": "hydrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48354",
+            "label": "substance with polar solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48359",
+            "label": "substance with protophilic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37176",
+            "label": "mononuclear parent hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48356",
+            "label": "substance with protic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15377",
+            "label": "water"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_17891",
+            "label": "substance with donor role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39141",
+            "label": "substance with Bronsted acid role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "rdfs:label",
+            "value": "H2O"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule141",
+            "value-type": "IRI"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-163820",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "obo:GOCHE_37527",
+            "label": "substance with acid role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33674",
+            "label": "s-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36902",
+            "label": "chalcogen hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33242",
+            "label": "inorganic hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24651",
+            "label": "hydroxides"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:52625",
+            "label": "inorganic hydroxy compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33692",
+            "label": "hydrides"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33693",
+            "label": "oxygen hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48360",
+            "label": "substance with amphiprotic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33608",
+            "label": "hydrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48354",
+            "label": "substance with polar solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48359",
+            "label": "substance with protophilic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37176",
+            "label": "mononuclear parent hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48356",
+            "label": "substance with protic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15377",
+            "label": "water"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_17891",
+            "label": "substance with donor role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39141",
+            "label": "substance with Bronsted acid role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule141",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "H2O"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-6807214",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "obo:GOCHE_37527",
+            "label": "substance with acid role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33674",
+            "label": "s-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36902",
+            "label": "chalcogen hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113519",
+            "label": "H2O"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33242",
+            "label": "inorganic hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24651",
+            "label": "hydroxides"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:52625",
+            "label": "inorganic hydroxy compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33692",
+            "label": "hydrides"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33693",
+            "label": "oxygen hydride"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48360",
+            "label": "substance with amphiprotic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33608",
+            "label": "hydrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48354",
+            "label": "substance with polar solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48359",
+            "label": "substance with protophilic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37176",
+            "label": "mononuclear parent hydride"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48356",
+            "label": "substance with protic solvent role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15377",
+            "label": "water"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_17891",
+            "label": "substance with donor role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39141",
+            "label": "substance with Bronsted acid role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule141",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "H2O"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159752",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33284",
+            "label": "substance with nutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33259",
+            "label": "elemental molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_67079",
+            "label": "substance with anti-inflammatory agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15379",
+            "label": "dioxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33262",
+            "label": "elemental oxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33263",
+            "label": "diatomic oxygen"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35472",
+            "label": "substance with anti-inflammatory drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33893",
+            "label": "substance with reagent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25362",
+            "label": "elemental molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_63248",
+            "label": "substance with oxidising agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_27027",
+            "label": "substance with micronutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule139",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "O2"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159761",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33284",
+            "label": "substance with nutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33259",
+            "label": "elemental molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_67079",
+            "label": "substance with anti-inflammatory agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15379",
+            "label": "dioxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33262",
+            "label": "elemental oxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33263",
+            "label": "diatomic oxygen"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35472",
+            "label": "substance with anti-inflammatory drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33893",
+            "label": "substance with reagent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25362",
+            "label": "elemental molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_63248",
+            "label": "substance with oxidising agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_27027",
+            "label": "substance with micronutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "O2"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule139",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159795",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33284",
+            "label": "substance with nutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33259",
+            "label": "elemental molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_67079",
+            "label": "substance with anti-inflammatory agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15379",
+            "label": "dioxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33262",
+            "label": "elemental oxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33263",
+            "label": "diatomic oxygen"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35472",
+            "label": "substance with anti-inflammatory drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33893",
+            "label": "substance with reagent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25362",
+            "label": "elemental molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_63248",
+            "label": "substance with oxidising agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_27027",
+            "label": "substance with micronutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule139",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "O2"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159803",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33284",
+            "label": "substance with nutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33259",
+            "label": "elemental molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_67079",
+            "label": "substance with anti-inflammatory agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15379",
+            "label": "dioxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33262",
+            "label": "elemental oxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33263",
+            "label": "diatomic oxygen"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35472",
+            "label": "substance with anti-inflammatory drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33893",
+            "label": "substance with reagent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25362",
+            "label": "elemental molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_63248",
+            "label": "substance with oxidising agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_27027",
+            "label": "substance with micronutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "rdfs:label",
+            "value": "O2"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule139",
+            "value-type": "IRI"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159819",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33284",
+            "label": "substance with nutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33259",
+            "label": "elemental molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_67079",
+            "label": "substance with anti-inflammatory agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15379",
+            "label": "dioxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33262",
+            "label": "elemental oxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33263",
+            "label": "diatomic oxygen"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35472",
+            "label": "substance with anti-inflammatory drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33893",
+            "label": "substance with reagent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25362",
+            "label": "elemental molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_63248",
+            "label": "substance with oxidising agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_27027",
+            "label": "substance with micronutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule139",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "O2"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159826",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33284",
+            "label": "substance with nutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33259",
+            "label": "elemental molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_67079",
+            "label": "substance with anti-inflammatory agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15379",
+            "label": "dioxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33262",
+            "label": "elemental oxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33263",
+            "label": "diatomic oxygen"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35472",
+            "label": "substance with anti-inflammatory drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33893",
+            "label": "substance with reagent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25362",
+            "label": "elemental molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_63248",
+            "label": "substance with oxidising agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_27027",
+            "label": "substance with micronutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "O2"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule139",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-163810",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33284",
+            "label": "substance with nutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33259",
+            "label": "elemental molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_67079",
+            "label": "substance with anti-inflammatory agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15379",
+            "label": "dioxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33262",
+            "label": "elemental oxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33263",
+            "label": "diatomic oxygen"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35472",
+            "label": "substance with anti-inflammatory drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33893",
+            "label": "substance with reagent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25362",
+            "label": "elemental molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_63248",
+            "label": "substance with oxidising agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_27027",
+            "label": "substance with micronutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "O2"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule139",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-163820",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33284",
+            "label": "substance with nutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33259",
+            "label": "elemental molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_67079",
+            "label": "substance with anti-inflammatory agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15379",
+            "label": "dioxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33262",
+            "label": "elemental oxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33263",
+            "label": "diatomic oxygen"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35472",
+            "label": "substance with anti-inflammatory drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33893",
+            "label": "substance with reagent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25362",
+            "label": "elemental molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_63248",
+            "label": "substance with oxidising agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_27027",
+            "label": "substance with micronutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule139",
+            "value-type": "IRI"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "O2"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-6807214",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33284",
+            "label": "substance with nutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33259",
+            "label": "elemental molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_67079",
+            "label": "substance with anti-inflammatory agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-113534",
+            "label": "O2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:15379",
+            "label": "dioxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33262",
+            "label": "elemental oxygen"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33263",
+            "label": "diatomic oxygen"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35472",
+            "label": "substance with anti-inflammatory drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33893",
+            "label": "substance with reagent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25362",
+            "label": "elemental molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_63248",
+            "label": "substance with oxidising agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24835",
+            "label": "inorganic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_27027",
+            "label": "substance with micronutrient role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule139",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "O2"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159752",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78433",
+            "label": "substance with refrigerant role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76414",
+            "label": "substance with propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35620",
+            "label": "substance with vasodilator agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16526",
+            "label": "carbon dioxide"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_38867",
+            "label": "substance with anaesthetic role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35554",
+            "label": "substance with cardiovascular drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25741",
+            "label": "oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48706",
+            "label": "substance with antagonist role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25701",
+            "label": "organic oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78017",
+            "label": "substance with food propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23014",
+            "label": "carbon oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:64708",
+            "label": "one-carbon compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52210",
+            "label": "substance with pharmacological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule138",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "CO2"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159761",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78433",
+            "label": "substance with refrigerant role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76414",
+            "label": "substance with propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35620",
+            "label": "substance with vasodilator agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16526",
+            "label": "carbon dioxide"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_38867",
+            "label": "substance with anaesthetic role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35554",
+            "label": "substance with cardiovascular drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25741",
+            "label": "oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48706",
+            "label": "substance with antagonist role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25701",
+            "label": "organic oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78017",
+            "label": "substance with food propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23014",
+            "label": "carbon oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:64708",
+            "label": "one-carbon compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52210",
+            "label": "substance with pharmacological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule138",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "CO2"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159795",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78433",
+            "label": "substance with refrigerant role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76414",
+            "label": "substance with propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35620",
+            "label": "substance with vasodilator agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16526",
+            "label": "carbon dioxide"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_38867",
+            "label": "substance with anaesthetic role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35554",
+            "label": "substance with cardiovascular drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25741",
+            "label": "oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48706",
+            "label": "substance with antagonist role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25701",
+            "label": "organic oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78017",
+            "label": "substance with food propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23014",
+            "label": "carbon oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:64708",
+            "label": "one-carbon compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52210",
+            "label": "substance with pharmacological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "rdfs:label",
+            "value": "CO2"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule138",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159803",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78433",
+            "label": "substance with refrigerant role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76414",
+            "label": "substance with propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35620",
+            "label": "substance with vasodilator agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16526",
+            "label": "carbon dioxide"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_38867",
+            "label": "substance with anaesthetic role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35554",
+            "label": "substance with cardiovascular drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25741",
+            "label": "oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48706",
+            "label": "substance with antagonist role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25701",
+            "label": "organic oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78017",
+            "label": "substance with food propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23014",
+            "label": "carbon oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:64708",
+            "label": "one-carbon compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52210",
+            "label": "substance with pharmacological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "CO2"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule138",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159819",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78433",
+            "label": "substance with refrigerant role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76414",
+            "label": "substance with propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35620",
+            "label": "substance with vasodilator agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16526",
+            "label": "carbon dioxide"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_38867",
+            "label": "substance with anaesthetic role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35554",
+            "label": "substance with cardiovascular drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25741",
+            "label": "oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48706",
+            "label": "substance with antagonist role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25701",
+            "label": "organic oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78017",
+            "label": "substance with food propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23014",
+            "label": "carbon oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:64708",
+            "label": "one-carbon compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52210",
+            "label": "substance with pharmacological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "rdfs:label",
+            "value": "CO2"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule138",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159826",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78433",
+            "label": "substance with refrigerant role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76414",
+            "label": "substance with propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35620",
+            "label": "substance with vasodilator agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16526",
+            "label": "carbon dioxide"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_38867",
+            "label": "substance with anaesthetic role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35554",
+            "label": "substance with cardiovascular drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25741",
+            "label": "oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48706",
+            "label": "substance with antagonist role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25701",
+            "label": "organic oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78017",
+            "label": "substance with food propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23014",
+            "label": "carbon oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:64708",
+            "label": "one-carbon compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52210",
+            "label": "substance with pharmacological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "CO2"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule138",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-163810",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78433",
+            "label": "substance with refrigerant role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76414",
+            "label": "substance with propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35620",
+            "label": "substance with vasodilator agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16526",
+            "label": "carbon dioxide"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_38867",
+            "label": "substance with anaesthetic role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35554",
+            "label": "substance with cardiovascular drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25741",
+            "label": "oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48706",
+            "label": "substance with antagonist role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25701",
+            "label": "organic oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78017",
+            "label": "substance with food propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23014",
+            "label": "carbon oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:64708",
+            "label": "one-carbon compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52210",
+            "label": "substance with pharmacological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule138",
+            "value-type": "IRI"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "CO2"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-163820",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78433",
+            "label": "substance with refrigerant role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76414",
+            "label": "substance with propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35620",
+            "label": "substance with vasodilator agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16526",
+            "label": "carbon dioxide"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_38867",
+            "label": "substance with anaesthetic role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35554",
+            "label": "substance with cardiovascular drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25741",
+            "label": "oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48706",
+            "label": "substance with antagonist role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25701",
+            "label": "organic oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78017",
+            "label": "substance with food propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23014",
+            "label": "carbon oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:64708",
+            "label": "one-carbon compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52210",
+            "label": "substance with pharmacological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule138",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "CO2"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-6807214",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:138675",
+            "label": "gas molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78433",
+            "label": "substance with refrigerant role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76414",
+            "label": "substance with propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-159751",
+            "label": "CO2"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35620",
+            "label": "substance with vasodilator agent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76413",
+            "label": "substance with greenhouse gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16526",
+            "label": "carbon dioxide"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75771",
+            "label": "substance with mouse metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_38867",
+            "label": "substance with anaesthetic role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75772",
+            "label": "substance with Saccharomyces cerevisiae metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_35554",
+            "label": "substance with cardiovascular drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76946",
+            "label": "substance with fungal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25741",
+            "label": "oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_48706",
+            "label": "substance with antagonist role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25701",
+            "label": "organic oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78295",
+            "label": "substance with food component role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:37577",
+            "label": "heteroatomic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_78017",
+            "label": "substance with food propellant role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23014",
+            "label": "carbon oxide"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_64047",
+            "label": "substance with food additive role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:64708",
+            "label": "one-carbon compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77974",
+            "label": "substance with food packaging gas role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52210",
+            "label": "substance with pharmacological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52211",
+            "label": "substance with physiological role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_46787",
+            "label": "substance with solvent role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule138",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "CO2"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159752",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:36586",
+            "label": "carbonyl compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36587",
+            "label": "organic oxo compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50646",
+            "label": "substance with bone density conservation agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25830",
+            "label": "p-quinones"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:17087",
+            "label": "ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16374",
+            "label": "menaquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36141",
+            "label": "quinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:3992",
+            "label": "cyclic ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25185",
+            "label": "menaquinones"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25481",
+            "label": "naphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26255",
+            "label": "prenylquinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26254",
+            "label": "prenylnaphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78277",
+            "label": "menatetrenone"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule140",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159761",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:36586",
+            "label": "carbonyl compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36587",
+            "label": "organic oxo compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50646",
+            "label": "substance with bone density conservation agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25830",
+            "label": "p-quinones"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:17087",
+            "label": "ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16374",
+            "label": "menaquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36141",
+            "label": "quinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:3992",
+            "label": "cyclic ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25185",
+            "label": "menaquinones"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25481",
+            "label": "naphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26255",
+            "label": "prenylquinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26254",
+            "label": "prenylnaphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78277",
+            "label": "menatetrenone"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule140",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159795",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:36586",
+            "label": "carbonyl compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36587",
+            "label": "organic oxo compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50646",
+            "label": "substance with bone density conservation agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25830",
+            "label": "p-quinones"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:17087",
+            "label": "ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16374",
+            "label": "menaquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36141",
+            "label": "quinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:3992",
+            "label": "cyclic ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25185",
+            "label": "menaquinones"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25481",
+            "label": "naphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26255",
+            "label": "prenylquinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26254",
+            "label": "prenylnaphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78277",
+            "label": "menatetrenone"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule140",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159803",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:36586",
+            "label": "carbonyl compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36587",
+            "label": "organic oxo compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50646",
+            "label": "substance with bone density conservation agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25830",
+            "label": "p-quinones"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:17087",
+            "label": "ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16374",
+            "label": "menaquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36141",
+            "label": "quinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:3992",
+            "label": "cyclic ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25185",
+            "label": "menaquinones"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25481",
+            "label": "naphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26255",
+            "label": "prenylquinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26254",
+            "label": "prenylnaphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78277",
+            "label": "menatetrenone"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule140",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159819",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:36586",
+            "label": "carbonyl compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36587",
+            "label": "organic oxo compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50646",
+            "label": "substance with bone density conservation agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25830",
+            "label": "p-quinones"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:17087",
+            "label": "ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16374",
+            "label": "menaquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36141",
+            "label": "quinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:3992",
+            "label": "cyclic ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25185",
+            "label": "menaquinones"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25481",
+            "label": "naphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26255",
+            "label": "prenylquinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26254",
+            "label": "prenylnaphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78277",
+            "label": "menatetrenone"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule140",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159826",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:36586",
+            "label": "carbonyl compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36587",
+            "label": "organic oxo compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50646",
+            "label": "substance with bone density conservation agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25830",
+            "label": "p-quinones"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:17087",
+            "label": "ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16374",
+            "label": "menaquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36141",
+            "label": "quinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:3992",
+            "label": "cyclic ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25185",
+            "label": "menaquinones"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25481",
+            "label": "naphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26255",
+            "label": "prenylquinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26254",
+            "label": "prenylnaphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78277",
+            "label": "menatetrenone"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule140",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-163810",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:36586",
+            "label": "carbonyl compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36587",
+            "label": "organic oxo compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50646",
+            "label": "substance with bone density conservation agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25830",
+            "label": "p-quinones"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:17087",
+            "label": "ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16374",
+            "label": "menaquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36141",
+            "label": "quinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:3992",
+            "label": "cyclic ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25185",
+            "label": "menaquinones"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25481",
+            "label": "naphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26255",
+            "label": "prenylquinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26254",
+            "label": "prenylnaphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78277",
+            "label": "menatetrenone"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "rdfs:label",
+            "value": "MK4"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule140",
+            "value-type": "IRI"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-163820",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:36586",
+            "label": "carbonyl compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36587",
+            "label": "organic oxo compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50646",
+            "label": "substance with bone density conservation agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25830",
+            "label": "p-quinones"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:17087",
+            "label": "ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16374",
+            "label": "menaquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36141",
+            "label": "quinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:3992",
+            "label": "cyclic ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25185",
+            "label": "menaquinones"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25481",
+            "label": "naphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26255",
+            "label": "prenylquinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26254",
+            "label": "prenylnaphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78277",
+            "label": "menatetrenone"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule140",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-6807214",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:36586",
+            "label": "carbonyl compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36962",
+            "label": "organochalcogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36587",
+            "label": "organic oxo compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36963",
+            "label": "organooxygen compound"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_77746",
+            "label": "substance with human metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52206",
+            "label": "substance with biochemical role role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75763",
+            "label": "substance with eukaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76971",
+            "label": "substance with Escherichia coli metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75768",
+            "label": "substance with mammalian metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75767",
+            "label": "substance with animal metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_75787",
+            "label": "substance with prokaryotic metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50646",
+            "label": "substance with bone density conservation agent role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25830",
+            "label": "p-quinones"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_25212",
+            "label": "substance with metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:17087",
+            "label": "ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:16374",
+            "label": "menaquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36141",
+            "label": "quinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:3992",
+            "label": "cyclic ketone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_52217",
+            "label": "substance with pharmaceutical role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33304",
+            "label": "chalcogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25185",
+            "label": "menaquinones"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25481",
+            "label": "naphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_33232",
+            "label": "substance with application role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:72695",
+            "label": "organic molecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26255",
+            "label": "prenylquinone"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:26254",
+            "label": "prenylnaphthoquinone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_76969",
+            "label": "substance with bacterial metabolite role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25367",
+            "label": "molecule"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_23888",
+            "label": "substance with drug role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_24432",
+            "label": "substance with biological role role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806362",
+            "label": "MK4"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:25806",
+            "label": "oxygen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:78277",
+            "label": "menatetrenone"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule140",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159752",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:90152",
+            "label": "2,3-epoxymenatetrenone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4 epoxide"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule142",
+            "value-type": "IRI"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159761",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:90152",
+            "label": "2,3-epoxymenatetrenone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule142",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4 epoxide"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159795",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:90152",
+            "label": "2,3-epoxymenatetrenone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule142",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4 epoxide"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159803",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:90152",
+            "label": "2,3-epoxymenatetrenone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "rdfs:label",
+            "value": "MK4 epoxide"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule142",
+            "value-type": "IRI"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159819",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:90152",
+            "label": "2,3-epoxymenatetrenone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule142",
+            "value-type": "IRI"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4 epoxide"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159826",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:90152",
+            "label": "2,3-epoxymenatetrenone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4 epoxide"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule142",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-163810",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:90152",
+            "label": "2,3-epoxymenatetrenone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule142",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4 epoxide"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-163820",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:90152",
+            "label": "2,3-epoxymenatetrenone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule142",
+            "value-type": "IRI"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4 epoxide"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-6807214",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:90152",
+            "label": "2,3-epoxymenatetrenone"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-ALL-6806366",
+            "label": "MK4 epoxide"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#SmallMolecule142",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "MK4 epoxide"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159722_R-HSA-159761",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159722",
+            "label": "pro-factor VII"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159722",
+            "label": "pro-factor VII"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P08709",
+            "label": "F7 Hsap"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159722",
+            "label": "pro-factor VII"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159722"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "pro-factor VII"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1648",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159734_R-HSA-159819",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159734",
+            "label": "pro-factor X"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159734",
+            "label": "pro-factor X"
+          },
+          {
+            "type": "class",
+            "id": "GO:0032991",
+            "label": "protein-containing complex"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159734"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Complex507",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "pro-factor X"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159739_R-HSA-159826",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159739",
+            "label": "F2(25-622)"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159739",
+            "label": "F2(25-622)"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159739",
+            "label": "F2(25-622)"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P00734",
+            "label": "F2 Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159739"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "F2(25-622)"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1652",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159740",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0017187",
+            "label": "peptidyl-glutamic acid carboxylation"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044238",
+            "label": "primary metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0018214",
+            "label": "protein carboxylation"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044237",
+            "label": "cellular metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0043412",
+            "label": "macromolecule modification"
+          },
+          {
+            "type": "class",
+            "id": "GO:0071704",
+            "label": "organic substance metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0019538",
+            "label": "protein metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008152",
+            "label": "metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044260",
+            "label": "cellular macromolecule metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008150",
+            "label": "Biological Process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044267",
+            "label": "cellular protein metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:1901564",
+            "label": "organonitrogen compound metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0009987",
+            "label": "cellular process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0006464",
+            "label": "cellular protein modification process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0043170",
+            "label": "macromolecule metabolic process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0018193",
+            "label": "peptidyl-amino acid modification"
+          },
+          {
+            "type": "class",
+            "id": "GO:0017187",
+            "label": "peptidyl-glutamic acid carboxylation"
+          },
+          {
+            "type": "class",
+            "id": "GO:0018200",
+            "label": "peptidyl-glutamic acid modification"
+          },
+          {
+            "type": "class",
+            "id": "GO:0036211",
+            "label": "protein modification process"
+          },
+          {
+            "type": "class",
+            "id": "GO:0006807",
+            "label": "nitrogen compound metabolic process"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "Edited: D'Eustachio, P, 0000-00-00 00:00:00"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "comment",
+            "value": "Gamma-carboxylation of a cluster of glutamate residues near the amino termini of thrombin, factor VII, factor IX, factor X, protein C, protein S, protein Z, and Gas 6 is required for these proteins to bind Ca++ and function efficiently in blood clotting. A single enzyme, vitamin K-dependent gamma-carboxylase, catalyzes the gamma-carboxylation of all eight proteins involved in clotting (Morris et al. 1995; Brenner et al. 1998; Spronk et al. 2000). In the carboxylation reaction, the enzyme binds its substrate protein via a sequence motif on the amino terminal side of the glutamate residues to be carboxylated (Furie et al. 1999), then processively carboxylates all glutamates in the cluster before releasing the substrate (Morris et al. 1995; Berkner 2000; Stenina et al. 2001). The reaction occurs in the endoplasmic reticulum (Bristol et al. 1996)."
+          },
+          {
+            "key": "rdfs:label",
+            "value": "Gamma-carboxylation of protein precursors"
+          },
+          {
+            "key": "contributor",
+            "value": "Authored: D'Eustachio, P, 2005-03-17 16:24:57"
+          },
+          {
+            "key": "comment",
+            "value": "http://www.reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159752",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016830",
+            "label": "carbon-carbon lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016831",
+            "label": "carboxy-lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003824",
+            "label": "catalytic activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016829",
+            "label": "lyase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159752"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#BiochemicalReaction373",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX gamma-carboxylates PROS1(25-676) (pro-protein S)"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159754_R-HSA-159819",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159754",
+            "label": "pro-factor X, uncarboxylated"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159754",
+            "label": "pro-factor X, uncarboxylated"
+          },
+          {
+            "type": "class",
+            "id": "GO:0032991",
+            "label": "protein-containing complex"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "pro-factor X, uncarboxylated"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159754"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Complex506",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159758_R-HSA-159752",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159758",
+            "label": "PROS1(25-676)"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159758",
+            "label": "PROS1(25-676)"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159758",
+            "label": "PROS1(25-676)"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P07225",
+            "label": "PROS1 Hsap"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "rdfs:label",
+            "value": "PROS1(25-676)"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159758"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1657",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum membrane"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159761",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016830",
+            "label": "carbon-carbon lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016831",
+            "label": "carboxy-lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003824",
+            "label": "catalytic activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016829",
+            "label": "lyase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#BiochemicalReaction369",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX gamma-carboxylates F7(21-466) (pro-factor VII)"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159761"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159765_R-HSA-159803",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159765",
+            "label": "3OHD110-F9(29-461)"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159765",
+            "label": "3OHD110-F9(29-461)"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159765",
+            "label": "3OHD110-F9(29-461)"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P00740",
+            "label": "F9 Hsap"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "rdfs:label",
+            "value": "3OHD110-F9(29-461)"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159765"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1644",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159770_R-HSA-159752",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159770",
+            "label": "pro-protein S"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159770",
+            "label": "pro-protein S"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159770",
+            "label": "pro-protein S"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P07225",
+            "label": "PROS1 Hsap"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1658",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "pro-protein S"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum membrane"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159770"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159772_R-HSA-159795",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159772",
+            "label": "pro-protein C"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0032991",
+            "label": "protein-containing complex"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159772",
+            "label": "pro-protein C"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Complex509",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "pro-protein C"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159772"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159795",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016830",
+            "label": "carbon-carbon lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016831",
+            "label": "carboxy-lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003824",
+            "label": "catalytic activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016829",
+            "label": "lyase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX gamma-carboxylates 3D-PROC(33-197) (pro-protein C light chain)"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#BiochemicalReaction372",
+            "value-type": "IRI"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159795"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159800_R-HSA-159826",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159800",
+            "label": "10xCbxE-F2(25-622)"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159800",
+            "label": "10xCbxE-F2(25-622)"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159800",
+            "label": "10xCbxE-F2(25-622)"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P00734",
+            "label": "F2 Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "10xCbxE-F2(25-622)"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1653",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159800"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159803",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016830",
+            "label": "carbon-carbon lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016831",
+            "label": "carboxy-lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003824",
+            "label": "catalytic activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016829",
+            "label": "lyase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#BiochemicalReaction368",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159803"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX gamma-carboxylates 3D-F9(29-461) (pro-factor IX)"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159819",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016830",
+            "label": "carbon-carbon lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016831",
+            "label": "carboxy-lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003824",
+            "label": "catalytic activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016829",
+            "label": "lyase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#BiochemicalReaction370",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX gamma-carboxylates 3D-F10(32-179) (pro-factor X light chain)"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159819"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159826",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016830",
+            "label": "carbon-carbon lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016831",
+            "label": "carboxy-lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003824",
+            "label": "catalytic activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016829",
+            "label": "lyase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#BiochemicalReaction371",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159826"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX gamma-carboxylates F2(25-622) (pro-prothrombin)"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159848_R-HSA-159761",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159848",
+            "label": "F7(21-466)"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159848",
+            "label": "F7(21-466)"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P08709",
+            "label": "F7 Hsap"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159848",
+            "label": "F7(21-466)"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159848"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1647",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "F7(21-466)"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159852_R-HSA-159795",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159852",
+            "label": "pro-protein C, uncarboxylated"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0032991",
+            "label": "protein-containing complex"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159852",
+            "label": "pro-protein C, uncarboxylated"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "rdfs:label",
+            "value": "pro-protein C, uncarboxylated"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159852"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Complex508",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159752_controller",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P38435",
+            "label": "GGCX Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1646",
+            "value-type": "IRI"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159860"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum membrane"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159761_controller",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P38435",
+            "label": "GGCX Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum membrane"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1646",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159860"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159795_controller",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P38435",
+            "label": "GGCX Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum membrane"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159860"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1646",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159803_controller",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P38435",
+            "label": "GGCX Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159860"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1646",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum membrane"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159819_controller",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P38435",
+            "label": "GGCX Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum membrane"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159860"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1646",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159826_controller",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P38435",
+            "label": "GGCX Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum membrane"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159860"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1646",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-163810_controller",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P38435",
+            "label": "GGCX Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1646",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum membrane"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159860"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-163820_controller",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P38435",
+            "label": "GGCX Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1646",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum membrane"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159860"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-6807214_controller",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159860",
+            "label": "GGCX"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P38435",
+            "label": "GGCX Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum membrane"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159860"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1646",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-159866_R-HSA-159803",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159866",
+            "label": "pro-factor IX"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159866",
+            "label": "pro-factor IX"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-159866",
+            "label": "pro-factor IX"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P00740",
+            "label": "F9 Hsap"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-159866"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1645",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "pro-factor IX"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-163795_R-HSA-163810",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163795",
+            "label": "pro-GAS6"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163795",
+            "label": "pro-GAS6"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163795",
+            "label": "pro-GAS6"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:Q14393",
+            "label": "GAS6 Hsap"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "pro-GAS6"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1662",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-163795"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-163810",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016830",
+            "label": "carbon-carbon lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016831",
+            "label": "carboxy-lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003824",
+            "label": "catalytic activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016829",
+            "label": "lyase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#BiochemicalReaction375",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX gamma-carboxylates GAS6(31-691) (pro-GAS6)"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-163810"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-163812_R-HSA-163810",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163812",
+            "label": "GAS6(31-691)"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163812",
+            "label": "GAS6(31-691)"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163812",
+            "label": "GAS6(31-691)"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:Q14393",
+            "label": "GAS6 Hsap"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1661",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GAS6(31-691)"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-163812"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-163816_R-HSA-163820",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163816",
+            "label": "PROZ(24-400)"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163816",
+            "label": "PROZ(24-400)"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P22891",
+            "label": "PROZ Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163816",
+            "label": "PROZ(24-400)"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-163816"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "PROZ(24-400)"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1659",
+            "value-type": "IRI"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-163820",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016830",
+            "label": "carbon-carbon lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016831",
+            "label": "carboxy-lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003824",
+            "label": "catalytic activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016829",
+            "label": "lyase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-163820"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#BiochemicalReaction374",
+            "value-type": "IRI"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX gamma-carboxylates PROZ(24-400) (pro-protein Z)"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-163838_R-HSA-163820",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163838",
+            "label": "pro-protein Z"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163838",
+            "label": "pro-protein Z"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P22891",
+            "label": "PROZ Hsap"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-163838",
+            "label": "pro-protein Z"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1660",
+            "value-type": "IRI"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-163838"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "pro-protein Z"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-6807212_R-HSA-6807214",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-6807212",
+            "label": "proOCN"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-6807212",
+            "label": "proOCN"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-6807212",
+            "label": "proOCN"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P02818",
+            "label": "BGLAP Hsap"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1663",
+            "value-type": "IRI"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-6807212"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "proOCN"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-6807214",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "BFO:0000015",
+            "label": "Process"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000003",
+            "label": "occurrent"
+          },
+          {
+            "type": "class",
+            "id": "GO:0008488",
+            "label": "gamma-glutamyl carboxylase activity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016830",
+            "label": "carbon-carbon lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003674",
+            "label": "Molecular Function"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016831",
+            "label": "carboxy-lyase activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0003824",
+            "label": "catalytic activity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016829",
+            "label": "lyase activity"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-6807214"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "GGCX gamma-carboxylates BGLAP(24-100) (pro-osteocalcin)"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#BiochemicalReaction376",
+            "value-type": "IRI"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/R-HSA-6807218_R-HSA-6807214",
+        "type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-6807218",
+            "label": "3xCbxE-BGLAP(24-100)"
+          }
+        ],
+        "inferred-type": [
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-6807218",
+            "label": "3xCbxE-BGLAP(24-100)"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "CHEBI:35352",
+            "label": "organonitrogen compound"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33694",
+            "label": "biomacromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33695",
+            "label": "chebi gene"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_15339",
+            "label": "substance with acceptor role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33675",
+            "label": "p-block molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000000001",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33579",
+            "label": "main group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "PR:000018263",
+            "label": "amino acid chain"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36080",
+            "label": "protein"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:51143",
+            "label": "nitrogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_50906",
+            "label": "substance with role role"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33582",
+            "label": "carbon group molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33285",
+            "label": "heteroorganic entity"
+          },
+          {
+            "type": "class",
+            "id": "gomodel:R-HSA-6807218",
+            "label": "3xCbxE-BGLAP(24-100)"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_51086",
+            "label": "substance with chemical role role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:36357",
+            "label": "polyatomic entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33302",
+            "label": "pnictogen molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_39142",
+            "label": "substance with Bronsted base role"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50047",
+            "label": "organic amino compound"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:33839",
+            "label": "macromolecule"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:50860",
+            "label": "organic molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:24431",
+            "label": "chemical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "CHEBI:23367",
+            "label": "molecular entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "UniProtKB:P02818",
+            "label": "BGLAP Hsap"
+          },
+          {
+            "type": "class",
+            "id": "obo:GOCHE_22695",
+            "label": "substance with base role"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "rdfs:label",
+            "value": "3xCbxE-BGLAP(24-100)"
+          },
+          {
+            "key": "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+            "value": "Reactome:R-HSA-6807218"
+          },
+          {
+            "key": "comment",
+            "value": "located_in endoplasmic reticulum lumen"
+          },
+          {
+            "key": "skos:exactMatch",
+            "value": "http://www.reactome.org/biopax/69/48887#Protein1664",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/a0747ce3-51a5-462b-b01b-2ba6aa0fd15f",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/a0a81207-0086-44d7-92ca-f324bc03e15a",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159819"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/a120a431-3db6-4826-a230-b62b56f0b30b",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/a1643060-b8c7-404f-9db8-7c090e53f8b2",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/a1e85a30-a280-4994-8e34-0b16e02bfda3",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159819"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/a334cc7c-714f-4b91-94f5-049b56d27def",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159803"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/a35e6fbb-3650-40c0-a60a-73a5b575d83e",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/a378bcdc-4d40-4962-8fae-adbce9248032",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/a3a27063-33cc-4968-8a1d-4c2f060f6b29",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163820"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/a5f11783-f377-42d7-9ab3-fb5f4a7993fa",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/a6ac211f-6717-4eb3-918a-cef415c0a2ff",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/aa869753-6275-40e9-a60e-e21fa6687f76",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159752"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/aaea6de8-3f72-4c07-8852-82fcbbd5a8f7",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/acb2335f-43fa-42ee-af04-7d5a54bb8fdb",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/ad421544-97b2-4572-b20e-af3cda40f272",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/af137c87-42c3-41e3-a2be-e8ffd51c8260",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/b0b13029-5ddf-4024-b800-8e4d19ee78e0",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/b2f9c756-c6e1-4960-8f48-bf658c2471c9",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159761"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/b462495d-3974-4622-8ea2-e35ec526272e",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159803"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/b6574392-5412-4d7a-832f-d51ead5ed3dd",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/b6cd0bae-035f-4687-8a95-423f31782083",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/b79d40e0-37a0-4845-b032-cc516762885f",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159795"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/b7e95526-9dad-47f9-bf12-5e69181b8909",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163820"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/b986887f-bda2-4eea-8249-0a26ad04a9f1",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-6807214"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/bb3f8c3d-8313-457d-b429-9ebc23772208",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159826"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/c0b2d668-b784-4eb6-b18c-3cfedfdf4474",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159795"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/c11b0466-af98-4221-816d-2c1730060000",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/c1abcdfe-5718-416e-9656-ededdf6a6ea9",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044444",
+            "label": "cytoplasmic part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044425",
+            "label": "membrane part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044424",
+            "label": "intracellular part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044446",
+            "label": "intracellular organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0031090",
+            "label": "organelle membrane"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044432",
+            "label": "endoplasmic reticulum part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/c1d1d2ad-07c3-46e4-804a-f403fdb3e309",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159761"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/c431d195-623d-427f-b6f1-5046fe121b41",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/c77f4e2b-c854-4655-8180-a6b481e53f37",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159819"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/c825dc30-4e7f-4a13-993f-3327436d9f4d",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163820"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/cc9da0db-1bcb-4a1a-b083-31bdb911142b",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/ce73b208-5db0-4d00-b25d-20f752070558",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159752"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/ceac13d0-1f70-4be2-8a1f-e9ff0c2556e8",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/ceb0ae14-7758-472b-b5f7-a18afb75176b",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/d16ce3d5-2416-4b79-82a3-ecbbeab5dc7c",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044444",
+            "label": "cytoplasmic part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044425",
+            "label": "membrane part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044424",
+            "label": "intracellular part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044446",
+            "label": "intracellular organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0031090",
+            "label": "organelle membrane"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044432",
+            "label": "endoplasmic reticulum part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/d1dd946e-cb6e-41d5-8909-132c4368e43c",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-6807214"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/d1ec9877-5e03-43d9-8dd7-002cdd3c89b1",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159761"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/d669eff9-c246-47b3-9c20-926d4f67c758",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159819"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/d74f872d-5dd6-42a3-ba59-783bc1fbec28",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/d78e91d4-babb-4c2c-a5f5-ea4c833dd370",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159795"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/d7a31c94-927a-4417-ab11-64b37b74e854",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/da6246e9-603b-4b24-a722-14cc9d3a74bf",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/ddab9cfa-0aa2-4aa5-a087-90f975805695",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159752"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/de4371d8-165c-408d-a061-f38a010b6bee",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/deb5882a-3611-4a6e-8d73-5554847ea1a9",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159761"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/e0d3cf6b-937c-4f74-904b-5800390f9cfc",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163820"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/e0efe1df-a2cc-4dab-a951-f43b29deea75",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163810"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/e14d9a72-5fd8-4324-b82d-3ff1da47e261",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163820"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/e3c6139a-5aa5-4234-a9c1-e955ff1f3c6f",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159819"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/e5f25c15-eae5-4781-bf05-175e14a09713",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163820"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/e8e9e290-cabc-4fe6-bc0c-dcbf37d67b32",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/ea3bc30c-8239-4aad-8490-30544766a385",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159826"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/eb01d55a-f26f-4ce0-9ae4-1f2f5a2b8237",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159819"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/eb8d53f2-9253-42c3-8493-aaa7dfdb7cd5",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/ec6292dd-9a2f-4ced-962b-d0d720fa7707",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/ef4385bd-6a9b-4d09-8f58-fb0d166f3165",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/ef7b4c33-61cc-462e-8828-67b73860e61b",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/efbbbfd1-8ec2-46ab-add4-726b0be7807a",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/f0cd3960-578f-41b3-9637-b6b1bea821df",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/f1c238f2-345e-4fbd-aa69-fb51c8c41730",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/f2671076-9974-4062-bd41-ba33d9abfe8c",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/f2e2e966-d997-46c2-b4b4-e50dff9f9f43",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/f3c418b5-a452-402b-aaaa-3573e06c9567",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/f4224d59-64fc-4b79-b83a-c8630a23eb83",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/f6d2d237-be34-4748-a732-be8047b1d2b7",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159795"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/fa11b462-4aad-44e4-9459-9db1c0580da3",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163820"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/fb4d9c74-2338-4933-846d-03cddbaf8b3c",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163810"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/fcb5d5d2-2efe-418f-a737-da149d13c9ee",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163810"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/fd12db53-bf56-4280-be0b-18eab48a045a",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/fd4b1be1-e16b-4fa9-8935-14ec4a52aad7",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159803"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/0a55dcd1-bd88-4498-b44c-ffe82f042e37",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159826"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/0ad66681-03f4-4f9f-b251-198865bb98c9",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/0d1faf16-3eb1-483e-9493-edf32b297933",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044444",
+            "label": "cytoplasmic part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044425",
+            "label": "membrane part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044424",
+            "label": "intracellular part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044446",
+            "label": "intracellular organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0031090",
+            "label": "organelle membrane"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044432",
+            "label": "endoplasmic reticulum part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/0db5791e-5248-4583-ab5b-cf016154e0e9",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159826"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/0e51849a-506f-4c56-8947-46cf56814628",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/013da203-2fe8-45d2-9af6-1a9926aa7ee5",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044444",
+            "label": "cytoplasmic part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044425",
+            "label": "membrane part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044424",
+            "label": "intracellular part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044446",
+            "label": "intracellular organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0031090",
+            "label": "organelle membrane"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044432",
+            "label": "endoplasmic reticulum part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/04fd7f07-b95d-4c57-80c9-033e9923bbc2",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159803"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/06c42e2e-e55c-448d-a075-429acc05bc4b",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159803"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/078ca553-97d8-46f6-b30c-bbea31578ec8",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/09c8a0cd-b252-4cdc-abdc-1617901f10ff",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159752"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/1a2cd64f-5853-4c6e-a514-a7a0fb9f4882",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/1fb7195f-7953-4432-8a60-58f102bd395b",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159803"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/13f6c892-1565-4c93-9c51-275638d66400",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159752"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/138773fa-9596-447f-997e-45498e45c3cc",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/16343f2f-2a71-4f6f-a04d-3b780b19bd05",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159795"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/165f8217-3442-4d8f-a1f7-16e84825da91",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/168434d0-a047-472c-bdc8-10e61859da19",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/169e1118-5978-4fa8-b947-17930a1577c0",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/18653e5e-181d-4a59-bfe0-11fcda23876f",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/19c9a196-e5e1-4ec5-8949-6f59333b924e",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/2c5c3fa5-169a-463b-955e-7dbd963b6eda",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163820"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/2c918482-610e-4314-b1bf-7480b06380d2",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-6807214"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/2e1bf2bc-8f3e-4749-8b34-25b5131d2db4",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/2fdd89fc-fb94-47d1-949a-c94f1999334c",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/2141cb0f-ebcc-43c3-bbda-32920604cf98",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044444",
+            "label": "cytoplasmic part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044425",
+            "label": "membrane part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044424",
+            "label": "intracellular part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044446",
+            "label": "intracellular organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0031090",
+            "label": "organelle membrane"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044432",
+            "label": "endoplasmic reticulum part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/27769e66-cf23-4869-9661-4125f89c1a9e",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/283c33e1-d105-44c5-890d-fde20c5ce2ed",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159826"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/3a5375fb-fd20-4333-9d5e-dd1208a93058",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/3aab4a1b-edd0-4bad-a871-d6344178c5db",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/3cbb3597-1540-4b0d-837e-916c6f1f3a48",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/3f71019f-5e9b-4bb8-9472-1c9145e2ee33",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/33024271-69b2-49bf-909b-0ee760083a51",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/36f7a066-3292-40d5-b72c-1db94a3f4eb2",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/3698ceb5-8ede-4638-8ce8-83428f04b089",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/372a1260-9a2c-422c-bd93-955346654d1b",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/4cf3eb54-80cf-4920-9267-d42aaac10715",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/4dc0ea39-6718-45db-b4b1-b7bea9d263ea",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159819"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/4f36b61e-377d-4b7b-9ade-00a9b5507c01",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/4fd83144-277a-44aa-b028-2ac3268b070d",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044444",
+            "label": "cytoplasmic part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044425",
+            "label": "membrane part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044424",
+            "label": "intracellular part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044446",
+            "label": "intracellular organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0031090",
+            "label": "organelle membrane"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044432",
+            "label": "endoplasmic reticulum part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/40d9ae9c-924d-47fc-9c94-d4ba17ee98c7",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/41cbfcb2-4f54-461d-a97b-d7cb2694c997",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163810"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/430e0076-0780-453f-9d5b-da1ed699b968",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159761"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/4376764a-f17c-45e6-9b01-aa2880467c74",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/47b6c5dd-88e1-4d07-9879-a26794dd4ff6",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-6807214"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/472d3282-8b68-456d-90c0-8073f7bd3fbe",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-6807214"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/474da563-20d6-40f3-a4be-e20d1a920fec",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159826"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/5a5cf34c-31f9-4976-84f5-f2f08731955b",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/5bc44e03-dbff-4852-b7d1-24dfcd946132",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/5c5d0caf-181e-4c84-b06f-b765a6fcdc89",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/5ce481d7-b324-45ce-aa26-7f680e83cc74",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/5de52312-1481-4fa4-91c7-43ef892504e1",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-6807214"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/5f51b4a9-3906-412f-906e-b06a29294a9c",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044444",
+            "label": "cytoplasmic part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044425",
+            "label": "membrane part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044424",
+            "label": "intracellular part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044446",
+            "label": "intracellular organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0031090",
+            "label": "organelle membrane"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044432",
+            "label": "endoplasmic reticulum part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/50a5118b-06b6-41e9-b23f-1d7252081dfa",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/5047410d-dbec-4d97-bbb1-563d03921691",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163810"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/51df44b5-02b7-4f90-a2d7-b1263ac7f25e",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/512260b5-031e-4fbc-9f92-25f7954c27bc",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044444",
+            "label": "cytoplasmic part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044425",
+            "label": "membrane part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044424",
+            "label": "intracellular part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044446",
+            "label": "intracellular organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0031090",
+            "label": "organelle membrane"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044432",
+            "label": "endoplasmic reticulum part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/52d2237e-0fe4-41bf-ab53-b95f5aafb800",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163810"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/5258236f-6054-4b06-a2e4-dc91b3eb0938",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159795"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/53af0903-c712-4681-bf3f-b816802b2b9e",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/533a2fdf-80d3-4f67-a104-ded6342689b8",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163810"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/55f0352a-3860-4cff-b958-2dccf48b5e1d",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159826"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/573260b6-1f4b-4b12-9ed7-cff536d120ef",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/6aff7f16-3ad6-4209-8a7e-126237476cb8",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/60cd61f5-6fa4-4998-89b6-194bc49222e6",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/614bf17c-9c83-4024-84c5-213ee06b6e18",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/6213754d-15db-4022-b1fc-d511e9be5d04",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159761"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/670d0a9d-e4c7-4ff2-8b44-f3fa433858a2",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-6807214"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/6944412d-2034-4faa-a877-9d322312cc2a",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/7a1ae5f6-17f4-430b-b7db-310fcf1f8e77",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/7a4c9864-572b-4b25-9cf5-7f8e015f054b",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/7ae4efed-7796-4963-9d1a-350114a00c71",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159752"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/7bbcb88f-e700-4115-aa2b-21591bfa0f04",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159803"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/7bd57c95-ad4b-4a5d-b64d-d2ae81f01433",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/7c4bb9c7-9826-4cba-ba8c-d1295fda7de9",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159761"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/731fe441-b236-4d08-b0d1-aea75ee8f917",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-6807214"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/740fbbb6-2da4-4b16-b797-beb924cb7c4a",
+        "type": [
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "GO:0044422",
+            "label": "organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044444",
+            "label": "cytoplasmic part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044425",
+            "label": "membrane part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044424",
+            "label": "intracellular part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044446",
+            "label": "intracellular organelle part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0031090",
+            "label": "organelle membrane"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0030000",
+            "label": "biological entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044432",
+            "label": "endoplasmic reticulum part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0044464",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000004",
+            "label": "independent continuant"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000000",
+            "label": "anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000002",
+            "label": "continuant"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000001",
+            "label": "entity"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005575",
+            "label": "cellular_component"
+          },
+          {
+            "type": "class",
+            "id": "GO:0005789",
+            "label": "endoplasmic reticulum membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000040",
+            "label": "material entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000006",
+            "label": "material anatomical entity"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000003",
+            "label": "connected anatomical structure"
+          },
+          {
+            "type": "class",
+            "id": "CARO:0000014",
+            "label": "cell part"
+          },
+          {
+            "type": "class",
+            "id": "GO:0016020",
+            "label": "membrane"
+          },
+          {
+            "type": "class",
+            "id": "BFO:0000030",
+            "label": "object"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/762e492f-cd80-42da-a934-fee90a434b94",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159761"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/79516bca-2f79-4667-9430-606c55f03261",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/8a6b7265-4c2b-401f-bd7e-2bfd92adfbbb",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/8ad103da-233c-477e-962f-51a20ee499e0",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159752"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/8c3a2aa4-1d3c-4ac9-8e9c-2c794ce68a7e",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/8d2fedbf-6fec-4ad3-905d-442f83cb0be6",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159795"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/8f45ff93-7edd-472b-aacc-8ed3e326066c",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-163810"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/80bdfbf4-e550-4538-9216-b191f844aaf5",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/808aa320-57f5-4a45-85d1-0d2c8424034b",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159752"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/81f76c7b-19d4-4300-865b-4720d2b51f60",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/826056ea-a1ce-411e-864b-fcafd32f25c3",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159826"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/84dd5769-f8ff-48cf-b57b-c44e33896196",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159819"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/85144ae1-29ae-4376-9dab-54fa1849047a",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/86f7216b-ed37-4ab4-8bdc-25de64200dc8",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/880063e0-7678-4353-a16a-368ab297a789",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/895a922e-60ec-44d2-87de-bdbf636dd3bf",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159795"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/8999511d-e865-4090-a0b1-b60ee8313f08",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/9d738ee0-173a-42d8-86b8-b834c0b01819",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/9d90308c-25df-40ab-8b32-11ae663975f3",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/929492a9-d7b7-48a7-b542-6bcbf358a4e0",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/93a7cd05-3adf-410a-86f7-5847848b084f",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/94612d3b-b231-4e65-b3e9-d84191c140f6",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159740"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          }
+        ]
+      },
+      {
+        "id": "gomodel:R-HSA-159740/97cf320d-c94d-4925-882a-3d45c96adeb4",
+        "type": [
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "inferred-type-with-all": [
+          {
+            "type": "class",
+            "id": "ECO:0000000",
+            "label": "evidence"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000311",
+            "label": "imported information"
+          },
+          {
+            "type": "class",
+            "id": "ECO:0000313",
+            "label": "imported information used in automatic assertion"
+          }
+        ],
+        "annotations": [
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "source",
+            "value": "Reactome:R-HSA-159803"
+          }
+        ]
+      }
+    ],
+    "facts": [
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159795",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:R-HSA-159740/0d1faf16-3eb1-483e-9493-edf32b297933",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/f4224d59-64fc-4b79-b83a-c8630a23eb83",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "This relation was asserted based on the location of the enabling molecule. "
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163820",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-163820",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/e14d9a72-5fd8-4324-b82d-3ff1da47e261",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/94612d3b-b231-4e65-b3e9-d84191c140f6",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163810",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-163810",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/36f7a066-3292-40d5-b72c-1db94a3f4eb2",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/52d2237e-0fe4-41bf-ab53-b95f5aafb800",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159752",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159752",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/09c8a0cd-b252-4cdc-abdc-1617901f10ff",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/33024271-69b2-49bf-909b-0ee760083a51",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159819",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159819",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/d669eff9-c246-47b3-9c20-926d4f67c758",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/169e1118-5978-4fa8-b947-17930a1577c0",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163810",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:R-HSA-159740/4fd83144-277a-44aa-b028-2ac3268b070d",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/168434d0-a047-472c-bdc8-10e61859da19",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "This relation was asserted based on the location of the enabling molecule. "
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159826",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:R-HSA-159740/R-HSA-159740",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/2fdd89fc-fb94-47d1-949a-c94f1999334c",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159795",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-HSA-159772_R-HSA-159795",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/5258236f-6054-4b06-a2e4-dc91b3eb0938",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/6aff7f16-3ad6-4209-8a7e-126237476cb8",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-6807214",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-6807214",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/614bf17c-9c83-4024-84c5-213ee06b6e18",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/670d0a9d-e4c7-4ff2-8b44-f3fa433858a2",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-6807214",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-6807214_controller",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/b986887f-bda2-4eea-8249-0a26ad04a9f1",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/165f8217-3442-4d8f-a1f7-16e84825da91",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159819",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159819",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/e3c6139a-5aa5-4234-a9c1-e955ff1f3c6f",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/5bc44e03-dbff-4852-b7d1-24dfcd946132",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159761",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159761",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/aaea6de8-3f72-4c07-8852-82fcbbd5a8f7",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/430e0076-0780-453f-9d5b-da1ed699b968",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159819",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:R-HSA-159740/R-HSA-159740",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/eb8d53f2-9253-42c3-8493-aaa7dfdb7cd5",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159819",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159819",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/a1e85a30-a280-4994-8e34-0b16e02bfda3",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/c431d195-623d-427f-b6f1-5046fe121b41",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163820",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-163820",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/c825dc30-4e7f-4a13-993f-3327436d9f4d",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/ceb0ae14-7758-472b-b5f7-a18afb75176b",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159752",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159752",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/cc9da0db-1bcb-4a1a-b083-31bdb911142b",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/8ad103da-233c-477e-962f-51a20ee499e0",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159761",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159761_controller",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/c1d1d2ad-07c3-46e4-804a-f403fdb3e309",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/3f71019f-5e9b-4bb8-9472-1c9145e2ee33",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159752",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159752_controller",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/de4371d8-165c-408d-a061-f38a010b6bee",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/13f6c892-1565-4c93-9c51-275638d66400",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163820",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-163820",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/c11b0466-af98-4221-816d-2c1730060000",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/fa11b462-4aad-44e4-9459-9db1c0580da3",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-6807214",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-6807214",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/1a2cd64f-5853-4c6e-a514-a7a0fb9f4882",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/731fe441-b236-4d08-b0d1-aea75ee8f917",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163810",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-163810",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/fcb5d5d2-2efe-418f-a737-da149d13c9ee",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/4376764a-f17c-45e6-9b01-aa2880467c74",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159761",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:R-HSA-159740/2141cb0f-ebcc-43c3-bbda-32920604cf98",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/4f36b61e-377d-4b7b-9ade-00a9b5507c01",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "This relation was asserted based on the location of the enabling molecule. "
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159803",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159803",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/ad421544-97b2-4572-b20e-af3cda40f272",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/b462495d-3974-4622-8ea2-e35ec526272e",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159826",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159826_controller",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/efbbbfd1-8ec2-46ab-add4-726b0be7807a",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/826056ea-a1ce-411e-864b-fcafd32f25c3",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159752",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:R-HSA-159740/c1abcdfe-5718-416e-9656-ededdf6a6ea9",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/b0b13029-5ddf-4024-b800-8e4d19ee78e0",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "This relation was asserted based on the location of the enabling molecule. "
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159761",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159761",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/a6ac211f-6717-4eb3-918a-cef415c0a2ff",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/762e492f-cd80-42da-a934-fee90a434b94",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159803",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:R-HSA-159740/740fbbb6-2da4-4b16-b797-beb924cb7c4a",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/a35e6fbb-3650-40c0-a60a-73a5b575d83e",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "This relation was asserted based on the location of the enabling molecule. "
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163820",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-HSA-163838_R-HSA-163820",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/a3a27063-33cc-4968-8a1d-4c2f060f6b29",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/078ca553-97d8-46f6-b30c-bbea31578ec8",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163820",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-163820_controller",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/a1643060-b8c7-404f-9db8-7c090e53f8b2",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/2c5c3fa5-169a-463b-955e-7dbd963b6eda",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163820",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:R-HSA-159740/5f51b4a9-3906-412f-906e-b06a29294a9c",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/85144ae1-29ae-4376-9dab-54fa1849047a",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "This relation was asserted based on the location of the enabling molecule. "
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163820",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-HSA-163816_R-HSA-163820",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/da6246e9-603b-4b24-a722-14cc9d3a74bf",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/e5f25c15-eae5-4781-bf05-175e14a09713",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159752",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:R-HSA-159740/R-HSA-159740",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/3aab4a1b-edd0-4bad-a871-d6344178c5db",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159826",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-HSA-159739_R-HSA-159826",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/ea3bc30c-8239-4aad-8490-30544766a385",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/f2e2e966-d997-46c2-b4b4-e50dff9f9f43",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159795",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159795",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/ef7b4c33-61cc-462e-8828-67b73860e61b",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/f6d2d237-be34-4748-a732-be8047b1d2b7",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159795",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159795",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/b79d40e0-37a0-4845-b032-cc516762885f",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/0e51849a-506f-4c56-8947-46cf56814628",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159795",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-HSA-159852_R-HSA-159795",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/80bdfbf4-e550-4538-9216-b191f844aaf5",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/895a922e-60ec-44d2-87de-bdbf636dd3bf",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159761",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159761",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/b6cd0bae-035f-4687-8a95-423f31782083",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/d1ec9877-5e03-43d9-8dd7-002cdd3c89b1",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163820",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-163820",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/e0d3cf6b-937c-4f74-904b-5800390f9cfc",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/372a1260-9a2c-422c-bd93-955346654d1b",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159826",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159826",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/b6574392-5412-4d7a-832f-d51ead5ed3dd",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/0a55dcd1-bd88-4498-b44c-ffe82f042e37",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159752",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159752",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/40d9ae9c-924d-47fc-9c94-d4ba17ee98c7",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/808aa320-57f5-4a45-85d1-0d2c8424034b",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-6807214",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-HSA-6807212_R-HSA-6807214",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/2c918482-610e-4314-b1bf-7480b06380d2",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/9d90308c-25df-40ab-8b32-11ae663975f3",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159752",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-HSA-159758_R-HSA-159752",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/50a5118b-06b6-41e9-b23f-1d7252081dfa",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/7ae4efed-7796-4963-9d1a-350114a00c71",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159819",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159819",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/a0a81207-0086-44d7-92ca-f324bc03e15a",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/f1c238f2-345e-4fbd-aa69-fb51c8c41730",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159752",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159752",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/ce73b208-5db0-4d00-b25d-20f752070558",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/880063e0-7678-4353-a16a-368ab297a789",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159803",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159803_controller",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/a334cc7c-714f-4b91-94f5-049b56d27def",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/86f7216b-ed37-4ab4-8bdc-25de64200dc8",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-6807214",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-6807214",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/f3c418b5-a452-402b-aaaa-3573e06c9567",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/472d3282-8b68-456d-90c0-8073f7bd3fbe",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159819",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-HSA-159754_R-HSA-159819",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/acb2335f-43fa-42ee-af04-7d5a54bb8fdb",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/4dc0ea39-6718-45db-b4b1-b7bea9d263ea",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159803",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159803",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/04fd7f07-b95d-4c57-80c9-033e9923bbc2",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/138773fa-9596-447f-997e-45498e45c3cc",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159761",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-HSA-159722_R-HSA-159761",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/deb5882a-3611-4a6e-8d73-5554847ea1a9",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/27769e66-cf23-4869-9661-4125f89c1a9e",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159795",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159795",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/c0b2d668-b784-4eb6-b18c-3cfedfdf4474",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/2e1bf2bc-8f3e-4749-8b34-25b5131d2db4",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159795",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159795",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/d78e91d4-babb-4c2c-a5f5-ea4c833dd370",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/7bd57c95-ad4b-4a5d-b64d-d2ae81f01433",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159761",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159761",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/b2f9c756-c6e1-4960-8f48-bf658c2471c9",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/7a1ae5f6-17f4-430b-b7db-310fcf1f8e77",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163810",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-HSA-163812_R-HSA-163810",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/fb4d9c74-2338-4933-846d-03cddbaf8b3c",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/81f76c7b-19d4-4300-865b-4720d2b51f60",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163820",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-163820",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/b7e95526-9dad-47f9-bf12-5e69181b8909",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/573260b6-1f4b-4b12-9ed7-cff536d120ef",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159826",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159826",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/3698ceb5-8ede-4638-8ce8-83428f04b089",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/474da563-20d6-40f3-a4be-e20d1a920fec",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163810",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-163810",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/3a5375fb-fd20-4333-9d5e-dd1208a93058",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/5047410d-dbec-4d97-bbb1-563d03921691",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159826",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159826",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/283c33e1-d105-44c5-890d-fde20c5ce2ed",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/5ce481d7-b324-45ce-aa26-7f680e83cc74",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159803",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-HSA-159765_R-HSA-159803",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/06c42e2e-e55c-448d-a075-429acc05bc4b",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/53af0903-c712-4681-bf3f-b816802b2b9e",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159803",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-HSA-159866_R-HSA-159803",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/6944412d-2034-4faa-a877-9d322312cc2a",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/7bbcb88f-e700-4115-aa2b-21591bfa0f04",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159761",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:R-HSA-159740/R-HSA-159740",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/18653e5e-181d-4a59-bfe0-11fcda23876f",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-6807214",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-6807214",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/d1dd946e-cb6e-41d5-8909-132c4368e43c",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/929492a9-d7b7-48a7-b542-6bcbf358a4e0",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159826",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-113519_R-HSA-159826",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/4cf3eb54-80cf-4920-9267-d42aaac10715",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/55f0352a-3860-4cff-b958-2dccf48b5e1d",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159803",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:R-HSA-159740/R-HSA-159740",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/8a6b7265-4c2b-401f-bd7e-2bfd92adfbbb",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163810",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:R-HSA-159740/R-HSA-159740",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/a5f11783-f377-42d7-9ab3-fb5f4a7993fa",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159795",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159795",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/16343f2f-2a71-4f6f-a04d-3b780b19bd05",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/19c9a196-e5e1-4ec5-8949-6f59333b924e",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-6807214",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:R-HSA-159740/013da203-2fe8-45d2-9af6-1a9926aa7ee5",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/93a7cd05-3adf-410a-86f7-5847848b084f",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "This relation was asserted based on the location of the enabling molecule. "
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159761",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-HSA-159848_R-HSA-159761",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/6213754d-15db-4022-b1fc-d511e9be5d04",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/9d738ee0-173a-42d8-86b8-b834c0b01819",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159826",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:R-HSA-159740/512260b5-031e-4fbc-9f92-25f7954c27bc",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/f2671076-9974-4062-bd41-ba33d9abfe8c",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "This relation was asserted based on the location of the enabling molecule. "
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159819",
+        "property": "BFO:0000066",
+        "property-label": "occurs in",
+        "object": "gomodel:R-HSA-159740/d16ce3d5-2416-4b79-82a3-ecbbeab5dc7c",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/7a4c9864-572b-4b25-9cf5-7f8e015f054b",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          },
+          {
+            "key": "comment",
+            "value": "This relation was asserted based on the location of the enabling molecule. "
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163810",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-163810",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/e0efe1df-a2cc-4dab-a951-f43b29deea75",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/f0cd3960-578f-41b3-9637-b6b1bea821df",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-6807214",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-6807214",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/47b6c5dd-88e1-4d07-9879-a26794dd4ff6",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/79516bca-2f79-4667-9430-606c55f03261",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159795",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:R-HSA-159740/R-HSA-159740",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/a0747ce3-51a5-462b-b01b-2ba6aa0fd15f",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163810",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-163810",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/0ad66681-03f4-4f9f-b251-198865bb98c9",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/533a2fdf-80d3-4f67-a104-ded6342689b8",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163810",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-163810_controller",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/41cbfcb2-4f54-461d-a97b-d7cb2694c997",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/60cd61f5-6fa4-4998-89b6-194bc49222e6",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159803",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159803",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/a120a431-3db6-4826-a230-b62b56f0b30b",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/fd4b1be1-e16b-4fa9-8935-14ec4a52aad7",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159752",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-HSA-159770_R-HSA-159752",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/ddab9cfa-0aa2-4aa5-a087-90f975805695",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/fd12db53-bf56-4280-be0b-18eab48a045a",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159826",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-HSA-159800_R-HSA-159826",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/bb3f8c3d-8313-457d-b429-9ebc23772208",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/8999511d-e865-4090-a0b1-b60ee8313f08",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163810",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-HSA-163795_R-HSA-163810",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/5c5d0caf-181e-4c84-b06f-b765a6fcdc89",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/8f45ff93-7edd-472b-aacc-8ed3e326066c",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-6807214",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:R-HSA-159740/R-HSA-159740",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/5a5cf34c-31f9-4976-84f5-f2f08731955b",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159803",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-159751_R-HSA-159803",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/ceac13d0-1f70-4be2-8a1f-e9ff0c2556e8",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/1fb7195f-7953-4432-8a60-58f102bd395b",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159803",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806362_R-HSA-159803",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/a378bcdc-4d40-4962-8fae-adbce9248032",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/97cf320d-c94d-4925-882a-3d45c96adeb4",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-6807214",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-HSA-6807218_R-HSA-6807214",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/ec6292dd-9a2f-4ced-962b-d0d720fa7707",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/5de52312-1481-4fa4-91c7-43ef892504e1",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159819",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159819_controller",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/3cbb3597-1540-4b0d-837e-916c6f1f3a48",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/84dd5769-f8ff-48cf-b57b-c44e33896196",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159752",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159752",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/aa869753-6275-40e9-a60e-e21fa6687f76",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/d7a31c94-927a-4417-ab11-64b37b74e854",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-163820",
+        "property": "BFO:0000050",
+        "property-label": "part of",
+        "object": "gomodel:R-HSA-159740/R-HSA-159740",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/af137c87-42c3-41e3-a2be-e8ffd51c8260",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159826",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159826",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/d74f872d-5dd6-42a3-ba59-783bc1fbec28",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/0db5791e-5248-4583-ab5b-cf016154e0e9",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159819",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-HSA-159734_R-HSA-159819",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/c77f4e2b-c854-4655-8180-a6b481e53f37",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/8c3a2aa4-1d3c-4ac9-8e9c-2c794ce68a7e",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159761",
+        "property": "RO:0002233",
+        "property-label": "has input",
+        "object": "gomodel:R-HSA-159740/R-ALL-113534_R-HSA-159761",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/e8e9e290-cabc-4fe6-bc0c-dcbf37d67b32",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/7c4bb9c7-9826-4cba-ba8c-d1295fda7de9",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159819",
+        "property": "RO:0002234",
+        "property-label": "has output",
+        "object": "gomodel:R-HSA-159740/R-ALL-6806366_R-HSA-159819",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/eb01d55a-f26f-4ce0-9ae4-1f2f5a2b8237",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/ef4385bd-6a9b-4d09-8f58-fb0d166f3165",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      },
+      {
+        "subject": "gomodel:R-HSA-159740/R-HSA-159795",
+        "property": "RO:0002333",
+        "property-label": "enabled by",
+        "object": "gomodel:R-HSA-159740/R-HSA-159860_R-HSA-159795_controller",
+        "annotations": [
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/51df44b5-02b7-4f90-a2d7-b1263ac7f25e",
+            "value-type": "IRI"
+          },
+          {
+            "key": "evidence",
+            "value": "gomodel:R-HSA-159740/8d2fedbf-6fec-4ad3-905d-442f83cb0be6",
+            "value-type": "IRI"
+          },
+          {
+            "key": "contributor",
+            "value": "https://reactome.org/content/detail/R-HSA-159740"
+          },
+          {
+            "key": "date",
+            "value": "2019-06-17"
+          },
+          {
+            "key": "providedBy",
+            "value": "https://reactome.org"
+          }
+        ]
+      }
+    ],
+    "annotations": [
+      {
+        "key": "state",
+        "value": "development"
+      },
+      {
+        "key": "contributor",
+        "value": "https://reactome.org/content/detail/R-HSA-159740"
+      },
+      {
+        "key": "date",
+        "value": "2019-06-17"
+      },
+      {
+        "key": "title",
+        "value": "Reactome:unexpanded:Gamma-carboxylation of protein precursors"
+      },
+      {
+        "key": "providedBy",
+        "value": "https://reactome.org"
+      }
+    ]
+  }
+}

--- a/packages/bbop-graph-noctua/src/noctua.js
+++ b/packages/bbop-graph-noctua/src/noctua.js
@@ -1,0 +1,2685 @@
+/**
+ * Purpose: Noctua editing operations ove a bbop-graph base.
+ *
+ * The base pieces are just subclasses of their analogs in bbop-graph.
+ *
+ * Now, a discussion if the structure an terminology of the evidence
+ * model.
+ *
+ * Definitions:
+ *
+ * - "model": the graph model as a whole
+ * - "seed": an evidence instance that is referenced ; a seed may only belong to a single clique
+ * - "sub_clique": the evidence subgraph pattern built off of a seed
+ * - "clique" the complete evidence subgraph, obtained by walking all edges from any node in it (should be same no matter what node)
+ * - "shared_struct": (currently) nodes of the clique that may be shared between different sub_cliques; for now, just pmid nodes
+ *
+ * Rules:
+ *
+ * A clique may only be removed from the graph, with its
+ * constitutent sub_cliques contained as referenced subgraphs,
+ * when:
+ * - all constituent sub_cliques have the "correct" structure
+ * - all clique nodes are in at least one sub_clique
+ * - sub_cliques only share structure in shared_struct nodes
+ *
+ * @see module:bbop-graph
+ * @module bbop-graph-noctua
+ */
+
+import us from "underscore";
+import bbop from "bbop-core";
+import bbop_model from "bbop-graph";
+import class_expression from "class-expression";
+
+var each = us.each;
+var keys = us.keys;
+
+///
+/// Debug helpers.
+///
+
+// Change these as necessary.
+var debug_map = {
+    // 'gomodel:5798651000000002/5798651000000003': 'set of upper jaw teeth',
+    // 'gomodel:5798651000000002/5798651000000004': 'sharp',
+    // 'gomodel:5798651000000002/5798651000000005': 'mouth',
+    // 'gomodel:5798651000000002/5798651000000006': 'pointed',
+    // 'gomodel:5798651000000002/5798651000000008': 'tongue',
+    // 'gomodel:5798651000000002/5798651000000009': 'lip',
+    // 'gomodel:5798651000000002/5798651000000010': 'tusk',
+    // 'gomodel:5798651000000002/5798651000000033': 'taste bud'
+};
+var dd = function(id){
+    var ret = id;
+    if( debug_map[id] ){
+	ret = debug_map[id];
+    }
+    return ret;
+};
+
+function log(){
+    console.log.apply(console, arguments);
+}
+
+///
+/// Annotations.
+///
+
+/**
+ * Edit annotations.
+ * Everything can take annotations.
+ *
+ * This structure of the raw key-value set has been updated in the
+ * wire protocol. It now looks like:
+ *
+ * : {"key": "contributor", "value": "GOC:kltm" }
+ *
+ * or:
+ *
+ * : {"key": "contributor", "value": "GOC:kltm", "value-type":"foo"}
+ *
+ * @constructor
+ * @param {Object} [kv_set] - optional a set of keys and values; a simple object
+ * @returns {this} new instance
+ */
+function annotation(kv_set){
+    this._id = bbop.uuid();
+
+    this._properties = {};
+
+    if( kv_set && bbop.what_is(kv_set) === 'object' ){
+
+	// Attempt to convert
+	if( kv_set['key'] && kv_set['value'] ){
+	    // var key = kv_set['key'];
+	    // var val = kv_set['value'];
+	    // var adj_set = {};
+	    // adj_set[key] = val;
+	    // Silently pass in value-type if there.
+	    this._properties = bbop.clone(kv_set);
+	}else{
+	    // TODO: Replace this at some point with the logger.
+	    log('bad annotation k/v set: ', kv_set);
+	}
+    }
+}
+
+/**
+ * The unique id of this annotation.
+ *
+ * @returns {String} string
+ */
+annotation.prototype.id = function(){
+    return this._id;
+};
+
+/**
+ * Add/modify a property by key and value (and maybe value_type).
+ *
+ * @param {String} key - string
+ * @param {String} [value] - string
+ * @param {String} [value_type] - string
+ * @returns {String|null} returns property is key
+ */
+annotation.prototype.annotation = function(key, value, value_type){
+
+    var anchor = this;
+    var ret = null;
+
+    // Set if the key and value are there.
+    if( key ){
+	if( typeof(value) !== 'undefined' ){
+	    anchor._properties['key'] = key;
+	    anchor._properties['value'] = value;
+
+	    // Add or get rid of value type depending.
+	    if( typeof(value_type) === 'undefined' ){
+		delete anchor._properties['value-type'];
+	    }else{
+		anchor._properties['value-type'] = value_type;
+	    }
+	}
+    }
+    ret = anchor._properties;
+
+    return ret;
+};
+
+/**
+ * Get/set annotation's key.
+ *
+ * @param {String} [key] - string
+ * @returns {String|null} returns string of annotation
+ */
+annotation.prototype.key = function(key){
+    var anchor = this;
+    if( key ){ anchor._properties['key'] = key; }
+    return anchor._properties['key'];
+};
+
+/**
+ * Get/set annotation's value.
+ *
+ * @param {String} [value] - string
+ * @returns {String|null} returns string of annotation
+ */
+annotation.prototype.value = function(value){
+    var anchor = this;
+    if( value ){ anchor._properties['value'] = value; }
+    return anchor._properties['value'];
+};
+
+/**
+ * Get/set annotation's value-type.
+ *
+ * @param {String} [value_type] - string
+ * @returns {String|null} returns string of annotation
+ */
+annotation.prototype.value_type = function(value_type){
+    var anchor = this;
+    if( value_type ){ anchor._properties['value-type'] = value_type; }
+    return anchor._properties['value-type'];
+};
+
+/**
+ * Delete a property by key.
+ *
+ * @param {String} key - string
+ * @returns {Boolean} true if not empty
+ */
+annotation.prototype.delete = function(){
+
+    var anchor = this;
+    var ret = false;
+
+    if( ! us.isEmpty(anchor._properties) ){
+	anchor._properties = {}; // nuke
+	ret = true;
+    }
+
+    return ret;
+};
+
+/**
+ * Clone an annotation.
+ *
+ * @returns {annotation} a fresh annotation for no shared structure
+ */
+annotation.prototype.clone = function(){
+    var anchor = this;
+
+    // Copy most of the data structure.
+    var a = {};
+    if( anchor.key() ){ a['key'] = anchor.key(); }
+    if( anchor.value() ){ a['value'] = anchor.value(); }
+    if( anchor.value_type() ){ a['value-type'] = anchor.value_type(); }
+
+    var new_ann = new annotation(a);
+
+    // Copy ID as well.
+    new_ann._id = anchor._id;
+
+    return new_ann;
+};
+
+///
+/// Generalized violations. Currently just around ShEx.
+///
+
+/**
+ * Model violations.
+ *
+ * These are currently ShEx oriented, but will be expanded into OWL,
+ * GO rules, etc. in the future.
+ *
+ * The current structure of the raw object looks like:
+ *
+ * : {"key": "contributor", "value": "GOC:kltm" }
+ *
+ * @constructor
+ * @param {Object} [vobj] - optional TBD object structure for violations
+ * @returns {this} new instance
+ */
+function violation(vobj){
+
+    this._id = bbop.uuid();
+    this._node = null;
+    this._explanations = [];
+
+    if( us.isString(vobj['node']) ){
+	this._node = bbop.clone(vobj['node']);
+    }else{
+	log('bad violation node: ', this._id);
+    }
+
+    if( us.isArray(vobj['explanations']) ){
+	this._explanations = bbop.clone(vobj['explanations']);
+    }else{
+	log('bad violation explanations: ', this._id);
+    }
+
+    return this;
+}
+
+/**
+ * The unique id of this violation.
+ *
+ * @returns {String} string
+ */
+violation.prototype.id = function(){
+    return this._id;
+};
+
+/**
+ * The unique id of this violation.
+ *
+ * @returns {String} string
+ */
+violation.prototype.node_id = function(){
+    return this._node;
+};
+
+/**
+ * The list of explanation objects for this violation.
+ *
+ * @returns {String} string
+ */
+violation.prototype.explanations = function(){
+    return this._explanations;
+};
+
+/**
+ * A clone of this violation object.
+ *
+ * @returns {violation} a fresh violation...
+ */
+violation.prototype.clone = function(){
+    var anchor = this;
+
+    var v = {};
+    v['node'] = anchor.node_id();
+    v['explanations'] = anchor.explanations();
+
+    // Our constructor will use all new material, so no problem.
+    var new_vio = new violation(v);
+    return new_vio;
+};
+
+///
+/// Generic internal annotation operations; dynamically attached to
+/// graph, node, and edge.
+///
+
+/**
+ * Get/set annotation list.
+ *
+ * @name annotations
+ * @function
+ * @param {Array} [in_anns] - list of annotations to clobber current list
+ * @returns {Array} list of all annotations
+ */
+function _annotations(in_anns){
+    if( us.isArray(in_anns) ){
+	this._annotations = in_anns;
+    }
+    return this._annotations;
+}
+
+/**
+ * Add annotation.
+ *
+ * @name add_annotation
+ * @function
+ * @param {annotation} in_ann - annotation to add
+ * @returns {Array} list of all annotations
+ */
+function _add_annotation(in_ann){
+    if( ! us.isArray(in_ann) ){
+	this._annotations.push(in_ann);
+    }
+    return this._annotations;
+}
+
+/**
+ * Get a sublist of annotation using the filter function. The filter
+ * function take a single annotation as an argument, and adds to the
+ * return list if it evaluates to true.
+ *
+ * @name get_annotations_by_filter
+ * @function
+ * @param {Function} filter - function described above
+ * @returns {Array} list of passing annotations
+ */
+function _get_annotations_by_filter(filter){
+
+    var anchor = this;
+    var ret = [];
+    each(anchor._annotations, function(ann){
+	var res = filter(ann);
+	if( res && res === true ){
+	    ret.push(ann);
+	}
+    });
+    return ret;
+}
+
+/**
+ * Get sublist of annotations with a certain key.
+ *
+ * @name get_annotations_by_key
+ * @function
+ * @param {String} key - key to look for.
+ * @returns {Array} list of list of annotations with that key
+ */
+function _get_annotations_by_key(key){
+    var anchor = this;
+
+    var ret = [];
+    each(anchor._annotations, function(ann){
+	if( ann.key() === key ){
+	    ret.push(ann);
+	}
+    });
+
+    return ret;
+}
+
+/**
+ * Get sublist of annotations with a certain ID.
+ *
+ * @name get_annotations_by_id
+ * @function
+ * @param {String} aid - annotation ID to look for
+ * @returns {Array} list of list of annotations with that ID
+ */
+function _get_annotation_by_id(aid){
+
+    var anchor = this;
+    var ret = null;
+    each(anchor._annotations, function(ann){
+	if( ann.id() === aid ){
+	    ret = ann;
+	}
+    });
+    return ret;
+}
+
+///
+/// Generic internal evidence (reference individuals) operations;
+/// dynamically attached to node and edge.
+///
+
+/**
+ * Get/set referenced subgraph list.
+ *
+ * Copies in new data.
+ *
+ * @name referenced_subgraph
+ * @function
+ * @param {Array} [subgraphs] - list of {graph} to clobber current list
+ * @returns {Array} list of all referenced subgraphs
+ */
+function _referenced_subgraphs(subgraphs){
+
+    if( us.isArray(subgraphs) ){
+
+	// Not copies, so add by replacement.
+	this._referenced_subgraphs = [];
+	// // Convert type.
+	each(subgraphs, function(g){
+	    //g.type('referenced');
+	    this._referenced_subgraphs.push(g.clone());
+	});
+
+    }
+    return this._referenced_subgraphs;
+}
+
+/**
+ * Add referenced subgraph.
+ *
+ * @name add_referenced_subgraph
+ * @function
+ * @param {graph} subgraph - subgraph to add
+ * @returns {Array} list of all subgraphs
+ */
+function _add_referenced_subgraph(subgraph){
+    if( ! us.isArray(subgraph) ){
+	//subgraph.type('referenced');
+	this._referenced_subgraphs.push(subgraph);
+    }
+    return this._referenced_subgraphs;
+}
+
+/**
+ * Get a sublist of referenced subgraphs using the filter
+ * function. The filter function take a single subgraph as an
+ * argument, and adds it to the return list if it evaluates to true.
+ *
+ * @name get_referenced_subgraphs_by_filter
+ * @function
+ * @param {Function} filter - function described above
+ * @returns {Array} list of passing subgraphs
+ */
+function _get_referenced_subgraphs_by_filter(filter){
+    var anchor = this;
+
+    var ret = [];
+    each(anchor._referenced_subgraphs, function(g){
+	var res = filter(g);
+	if( res && res === true ){
+	    ret.push(g);
+	}
+    });
+
+    return ret;
+}
+
+/**
+* Get a referenced_subgraph with a certain ID.
+ *
+ * @name get_referenced_subgraph_by_id
+ * @function
+ * @param {String} iid - referenced_individual ID to look for
+ * @returns {Object|null} referenced_subgraph with that ID
+ */
+function _get_referenced_subgraph_by_id(iid){
+    var anchor = this;
+
+    var ret = null;
+    each(anchor._referenced_subgraphs, function(g){
+	if( g.id() === iid ){
+	    ret = g;
+	}
+    });
+
+    return ret;
+}
+
+/**
+ * Returns a list with the following structure:
+ *
+ * : [ { id: <ID>,
+ * :     class_expressions: [{class_expression}, ...],
+ * :     anntations: [{annotation}, ...] },
+ * :   ...
+ * : ]
+ *
+ * Each top-level element in the list represents the core information
+ * of a single referenced graph for a node or edge in this model.
+ *
+ * Keep in mind that this may be most useful in the GO Noctua use case
+ * as reference subgraphs with singleton elements, where the class(es)
+ * are evidence and the annotations keep things such as source
+ * (e.g. PMID), etc.
+ *
+ * @name get_referenced_subgraph_profiles
+ * @function
+ * @param {Function} [extractor] extraction functions to use instead of default
+ * @returns {Array} list of referenced_individual information
+ */
+function _get_referenced_subgraph_profiles(extractor){
+    var anchor = this;
+
+    //
+    function extractor_default(g){
+	var ret = null;
+
+	// If singleton.
+	if( g.all_nodes().length === 1 ){
+	    var ind = g.all_nodes()[0];
+
+	    // Base.
+	    var prof = {
+		id: null,
+		class_expressions: [],
+		annotations: []
+	    };
+
+	    // Referenced instance ID.
+	    prof['id'] = ind.id();
+
+	    // Collect class expressions and annotations.
+	    each(ind.types(), function(ce){
+		prof['class_expressions'].push(ce);
+	    });
+	    each(ind.annotations(), function(ann){
+		prof['annotations'].push(ann);
+	    });
+
+	    //
+	    ret = prof;
+	}
+
+	return ret;
+    }
+
+    // If we are using the simple standard.
+    if( typeof(extractor) !== 'function' ){
+	extractor = extractor_default;
+    }
+
+    // Run the extractor over the referenced subraph in the calling
+    // node.
+    var ret = [];
+    each(anchor.referenced_subgraphs(), function(g){
+	var extracted = extractor(g);
+	if( extracted ){
+	    ret.push(extracted);
+	}
+    });
+
+    return ret;
+}
+
+/**
+ * Returns a list with the following structure:
+ *
+ * : [ { id: <ID>,
+ * :     cls: <ID>,
+ * :     source: <STRING>,
+ * :     date: <STRING>,
+ * :     etc
+ * :   },
+ * :   ...
+ * : ]
+ *
+ * Each top-level element in the list represents the core information
+ * in a simple (GO-style) element. This is essentially a distilled
+ * version of get_referenced_individual_profiles for cases where that
+ * is modelling simple piece of evidence (single non-nested class
+ * expression and a set know list of annotations).
+ *
+ * @name get_basic_evidence
+ * @function
+ * @param {Array} annotation_ids - list of strings that identify the annotation keys that will be captured--
+ * @returns {Array} list of referenced_individual simple evidence information.
+ */
+function _get_basic_evidence(annotation_ids){
+    var anchor = this;
+
+    var ret = [];
+
+    // Get hash of the annotation keys present.
+    var test = us.object(us.map(annotation_ids,
+				function(e){ return [e, true]; }));
+
+    each(anchor.get_referenced_subgraph_profiles(), function(cmplx_prof){
+	//console.log(cmplx_prof);
+
+	// Only add conformant referenced individuals.
+	if( cmplx_prof.id && ! us.isEmpty(cmplx_prof.class_expressions) ){
+
+	    // Base.
+	    //console.log(cmplx_prof.class_expressions);
+	    var basic_prof = {
+		id: cmplx_prof.id,
+		cls: cmplx_prof.class_expressions[0].to_string()
+	    };
+
+	    // Match and clobber.
+	    each(cmplx_prof.annotations, function(ann){
+		//console.log(ann);
+		if( test[ann.key()] ){
+		    basic_prof[ann.key()] = ann.value();
+		}
+	    });
+
+	    //console.log(basic_prof);
+	    ret.push(basic_prof);
+	}
+
+    });
+
+    return ret;
+}
+
+///
+/// Next, get some subclasses working for the core triumvirate: graph,
+/// node, edge. Start with graph.
+///
+
+var bbop_graph = bbop_model.graph;
+
+/**
+ * Sublcass of bbop-graph for use with Noctua ideas and concepts.
+ *
+ * Unlike the superclass, can take an id as an argument, or will
+ * generate on on its own.
+ *
+ * @constructor
+ * @see module:bbop-graph
+ * @alias graph
+ * @param {String} [new_id] - new id; otherwise new unique generated
+ * @returns {this}
+ */
+function noctua_graph(new_id){
+    bbop_graph.call(this);
+    this._is_a = 'bbop-graph-noctua.graph';
+
+    // Deal with id or generate a new one.
+    if( typeof(new_id) !== 'undefined' ){
+	this.id(new_id);
+    }
+
+    // The old edit core.
+    this.core = {
+	'edges': {}, // map of id to edit_edge - edges not completely anonymous
+	'node_order': [], // initial table order on redraws
+	'node2elt': {}, // map of id to physical object id
+	'elt2node': {},  // map of physical object id to id
+	// Remeber that edge ids and elts ids are the same, so no map
+	// is needed.
+	'edge2connector': {}, // map of edge id to virtual connector id
+	'connector2edge': {}  // map of virtual connector id to edge id
+    };
+
+    this._annotations = [];
+    //this._referenced_subgraphs = []; // not for graph yet, or maybe ever
+
+    // Some things that come up in live noctua environments. These are
+    // graph properties that may or may not be there. If unknown,
+    // null; if positively true (bad), true; may be false otherwise.
+    this._inconsistent_p = null;
+    this._modified_p = null;
+
+    // New section as we work out how violations operate.
+    this._violations = [];
+    this._valid_p = true;
+    this._valid_owl_p = true;
+    this._valid_shex_p = true;
+}
+bbop.extend(noctua_graph, bbop_graph);
+
+/**
+ * Create an edge for use in internal operations.
+ *
+ * @param {string} subject - node id string or node
+ * @param {string} object - node id string or node
+ * @param {string} [predicate] - a user-friendly description of the node
+ * @returns {edge} bbop model edge
+ */
+noctua_graph.prototype.create_edge = function(subject, object, predicate){
+    return new noctua_edge(subject, object, predicate);
+};
+
+/**
+ * Create a node for use in internal operations.
+ *
+ * @param {string} id - a unique id for the node
+ * @param {string} [label] - a user-friendly description of the node
+ * @param {Array} [types] - list of types to pre-load
+ * @param {Array} [inferred_types] - list of inferred types to pre-load
+ * @returns {node} new bbop model node
+ */
+noctua_graph.prototype.create_node = function(id, label, types, root_types, inferred_types, inferred_types_with_all){
+    return new noctua_node(id, label, types, root_types, inferred_types, inferred_types_with_all);
+};
+
+/**
+ * Create a clone of the graph.
+ *
+ * Naturally, ID is copied.
+ *
+ * @returns {graph} bbop model graph
+ */
+noctua_graph.prototype.clone = function(){
+    var anchor = this;
+
+    var new_graph = anchor.create_graph();
+
+    // Collect the nodes and edges.
+    each(anchor.all_nodes(), function(node){
+	new_graph.add_node(node.clone());
+    });
+    each(anchor.all_edges(), function(edge){
+	new_graph.add_edge(edge.clone());
+    });
+
+    // Collect other information.
+    new_graph.default_predicate = anchor.default_predicate;
+    new_graph._id = anchor._id;
+
+    // Copy new things: annotations.
+    each(anchor._annotations, function(annotation){
+	new_graph._annotations.push(annotation.clone());
+    });
+
+    // Copy other properties over.
+    new_graph._inconsistent_p = anchor._inconsistent_p;
+    new_graph._modified_p = anchor._modified_p;
+
+    // Copy violation information over.
+    each(anchor._violations, function(v){
+	new_graph._violations.push(v.clone());
+    });
+    new_graph._valid_p = anchor._valid_p;
+    new_graph._valid_owl_p = anchor._valid_owl_p;
+    new_graph._valid_shex_p = anchor._valid_shex_p;
+
+    return new_graph;
+};
+
+/**
+ * Create a graph for use in internal operations.
+ *
+ * @returns {graph} bbop model graph
+ */
+noctua_graph.prototype.create_graph = function(){
+    return new noctua_graph();
+};
+
+/**
+ * Add an ID to the graph.
+ *
+ * Use .id() instead.
+ *
+ * @deprecated
+ * @see module:bbop-graph#id
+ * @param {String} id - string
+ * @returns {String} string
+ */
+noctua_graph.prototype.add_id = function(id){
+    return this.id(id);
+};
+
+/**
+ * Get the ID from the graph.
+ *
+ * Use .id() instead.
+ *
+ * @deprecated
+ * @see module:bbop-graph#id
+ * @returns {String} string
+ */
+noctua_graph.prototype.get_id = function(){
+    return this.id();
+};
+
+/**
+ * Returns true if the model had the "inconsistent-p" property when
+ * built.
+ *
+ * @returns {Boolean|null} inconsistent or not; null if unknown
+ */
+noctua_graph.prototype.inconsistent_p = function(){
+    return this._inconsistent_p;
+};
+
+/**
+ * Returns true if the model had the "modified-p" property when
+ * built.
+ *
+ * @returns {Boolean|null} inconsistent or not; null if unknown
+ */
+noctua_graph.prototype.modified_p = function(){
+    return this._modified_p;
+};
+
+/**
+ * Returns boolean on whether the returned model is /completely/
+ * valid; true if there is no logic to probe (this is a temporary
+ * measure until reasoner is "always on").
+ *
+ * @returns {Boolean} p - bool
+ */
+noctua_graph.prototype.valid_p = function(){
+    return this._valid_p;
+};
+
+/**
+ * Returns boolean on whether the returned model is valid according to
+ * the owl reasoner; true if there is no logic to probe (this is a temporary
+ * measure until reasoner is "always on").
+ *
+ * @returns {Boolean} p - bool
+ */
+noctua_graph.prototype.valid_owl_p = function(){
+    return this._valid_owl_p;
+};
+
+/**
+ * Returns boolean on whether the returned model is valid according to
+ * ShEx shapes in Minerva; true if there is no logic to probe (this is
+ * a temporary measure until reasoner is "always on").
+ *
+ * @returns {Boolean} p - bool
+ */
+noctua_graph.prototype.valid_shex_p = function(){
+    return this._valid_shex_p;
+};
+
+/**
+ * Returns an array of objects that describe the ShEx violations
+ * found in a model.
+ *
+ * @returns {Array} violations or an empty list if none
+ */
+noctua_graph.prototype.violations = function(){
+    return this._violations;
+};
+
+/**
+ * Return an edge by is ID.
+ *
+ * @param {String} node_id - the ID of the {edge}
+ * @returns {Array|Null} - Returns a list of 'violation' found in the graph for a given id.
+ */
+noctua_graph.prototype.get_violations_by_id = function(node_id){
+    var ret = [];
+
+    // TODO: needs to be optimized once we figure out how we handle
+    // shex + owl + whatever as general objects in here.
+    each(this.violations(), function(v){
+	if( v.node_id() === node_id ){
+	    ret.push(v.clone());
+	}
+    });
+
+    return ret;
+};
+
+/**
+ * Get the ID from the graph.
+ *
+ * @param {node} enode - noctua node
+ * @returns {Boolean} true on new node
+ */
+noctua_graph.prototype.add_node = function(enode){
+    // Super call: add it to the general graph.
+    bbop_graph.prototype.add_node.call(this, enode);
+
+    var ret = false;
+
+    // Add/update node.
+    var enid = enode.id();
+    //this.core['nodes'][enid] = enode; // add to nodes
+
+    // Only create a new elt ID and order if one isn't already in
+    // there (or reuse things to keep GUI working smoothly).
+    var elt_id = this.core['node2elt'][enid];
+    if( ! elt_id ){ // first time
+	this.core['node_order'].unshift(enid); // add to default order
+	elt_id = bbop.uuid(); // generate the elt id we'll use from now on
+	this.core['node2elt'][enid] = elt_id; // map it
+	this.core['elt2node'][elt_id] = enid; // map it
+	ret = true;
+    }
+
+    return ret;
+};
+
+/**
+ * Add a node into the graph modeled from the the JSON-LD lite model.
+ * Creates or adds types and annotations as necessary.
+ *
+ * @param {Object} indv - hash rep of graph individual from Minerva response?
+ * @returns {node|null}
+ */
+noctua_graph.prototype.add_node_from_individual = function(indv){
+    var anchor = this;
+
+    var new_node = null;
+
+    // Add individual to edit core if properly structured.
+    var iid = indv['id'];
+    if( iid ){
+	//var nn = new bbop.model.node(indv['id']);
+	//var meta = {};
+	//ll('indv');
+
+	// See if there is type info that we want to add.
+	// Create the node.
+	var itypes = indv['type'] || [];
+	var root_itypes = indv['root-type'] || [];
+	var inf_itypes = indv['inferred-type'] || [];
+	var inf_itypes_with_all = indv['inferred-type-with-all'] || [];
+	new_node = anchor.create_node(iid, null, itypes,
+                                      root_itypes, inf_itypes,
+                                      inf_itypes_with_all);
+
+	// See if there is type info that we want to add.
+	var ianns = indv['annotations'] || [];
+	if( us.isArray(ianns) ){
+	    // Add the annotations individually.
+	    each(ianns, function(ann_kv_set){
+		var na = new annotation(ann_kv_set);
+		new_node.add_annotation(na);
+	    });
+	}
+
+	anchor.add_node(new_node);
+    }
+
+    return new_node;
+};
+
+/**
+ * Return the "table" order of the nodes.
+ *
+ * @returns {Array} node order by id?
+ */
+noctua_graph.prototype.edit_node_order = function(){
+    return this.core['node_order'] || [];
+};
+
+/**
+ * Return a node's element id.
+ *
+ * @returns {String|null} node element id
+ */
+noctua_graph.prototype.get_node_elt_id = function(enid){
+    return this.core['node2elt'][enid] || null;
+};
+
+/**
+ * Return a copy of a {node} by its element id.
+ *
+ * @returns {node|null} node
+ */
+noctua_graph.prototype.get_node_by_elt_id = function(elt_id){
+    var ret = null;
+    var enid = this.core['elt2node'][elt_id] || null;
+    if( enid ){
+	ret = this.get_node(enid) || null;
+    }
+    return ret;
+};
+
+/**
+ * Return a copy of a {node} by its corresponding Minerva JSON rep
+ * individual.
+ *
+ * @returns {node|null} node
+ */
+noctua_graph.prototype.get_node_by_individual = function(indv){
+    var anchor = this;
+
+    var ret = null;
+
+    // Get node from graph if individual rep is properly structured.
+    var iid = indv['id'];
+    if( iid ){
+	ret = this.get_node(iid) || null;
+    }
+
+    return ret;
+};
+
+/**
+ * Return a hash of node ids to nodes.
+ * Real, not a copy.
+ *
+ * @see module:bbop-graph#all_nodes
+ * @returns {Object} node ids to nodes
+ */
+noctua_graph.prototype.get_nodes = function(){
+    return this._nodes || {};
+};
+
+/**
+ * Remove a node from the graph.
+ *
+ * @param {String} node_id - the id for a node
+ * @param {Boolean} [clean_p] - remove all edges connects to node (default false)
+ * @returns {Boolean} true if node found and destroyed
+ */
+noctua_graph.prototype.remove_node = function(node_id, clean_p){
+    var anchor = this;
+
+    var ret = false;
+    var enode = anchor.get_node(node_id);
+    if( enode ){
+	ret = true;
+
+	///
+	/// First, remove all subclass decorations.
+	///
+
+	// Also remove the node from the order list.
+	// TODO: Is this a dumb scan?
+	var ni = this.core['node_order'].indexOf(node_id);
+	if( ni !== -1 ){
+	    this.core['node_order'].splice(ni, 1);
+	}
+
+	// Clean the maps.
+	var elt_id = this.core['node2elt'][node_id];
+	delete this.core['node2elt'][node_id];
+	delete this.core['elt2node'][elt_id];
+
+	///
+	/// We want to maintain superclass compatibility.
+	///
+
+	// Finally, remove the node itself.
+	bbop_graph.prototype.remove_node.call(this, node_id, clean_p);
+    }
+
+    return ret;
+};
+
+/**
+ * Add an edge to the graph. Remember that edges are no anonymous
+ * edges here.
+ *
+ * @param {edge} eedge - a bbop-graph-noctua#edge
+ */
+noctua_graph.prototype.add_edge = function(eedge){
+
+    // Super.
+    bbop_graph.prototype.add_edge.call(this, eedge);
+
+    // Sub.
+   var eeid = eedge.id();
+   if( ! eeid ){ throw new Error('edge not of bbop-graph-noctua'); }
+   this.core['edges'][eeid] = eedge;
+};
+
+/**
+ * Add an edge to the graph using a "fact" as the seed.
+ * Creates and adds annotations as necessary.
+ *
+ * @param {} fact - JSON structure representing a fact
+ * @returns {edge} newly created edge
+ */
+noctua_graph.prototype.add_edge_from_fact = function(fact){
+    var anchor = this;
+
+    var new_edge = null;
+
+    // Add individual to edit core if properly structured.
+    var sid = fact['subject'];
+    var oid = fact['object'];
+    var pid = fact['property'];
+    var plbl = fact['property-label'];
+    var anns = fact['annotations'] || [];
+    if( sid && oid && pid ){
+
+	new_edge = anchor.create_edge(sid, oid, pid);
+	if( ! us.isArray(anns) ){
+	    throw new Error('annotations is wrong');
+	}else{
+	    // Add the annotations individually.
+	    each(anns, function(ann_kv_set){
+		var na = new annotation(ann_kv_set);
+		new_edge.add_annotation(na);
+	    });
+	}
+	// Add edge if possible.
+	if( plbl ){
+	    new_edge.label(plbl);
+	}
+
+	// Add and ready to return edge.
+	anchor.add_edge(new_edge);
+    }
+
+    return new_edge;
+};
+
+/**
+ * Return an edge by is ID.
+ *
+ * @param {String} edge_id - the ID of the {edge}
+ * @returns {edge|null} - the {edge}
+ */
+noctua_graph.prototype.get_edge_by_id = function(edge_id){
+    var ret = null;
+    var ep = this.core['edges'][edge_id];
+    if( ep ){ ret = ep; }
+    return ret;
+};
+
+/**
+ * Return an edge ID by it's associated connector ID if extant.
+ *
+ * @param {String} cid - the ID of the connector.
+ * @returns {String} - the ID of the associated edge
+ */
+noctua_graph.prototype.get_edge_id_by_connector_id = function(cid){
+    return this.core['connector2edge'][cid] || null;
+};
+
+/**
+ * Return a connector by it's associated edge ID if extant.
+ *
+ * @param {String} eid - the ID of the edge
+ * @returns {String} - the connector ID
+ */
+noctua_graph.prototype.get_connector_id_by_edge_id = function(eid){
+    return this.core['edge2connector'][eid] || null;
+};
+
+/**
+ * Remove an edge to the graph.
+ * The edge as referenced.
+ *
+ * @param {String} subject_id - subject by ID
+ * @param {String} object_id - object by ID
+ * @param {String} [predicate_id] - predicate ID or default
+ * @returns {Boolean} true if such an edge was found and deleted, false otherwise
+ */
+// noctua_graph.prototype.remove_edge = function(subject_id, object_id, predicate_id){
+//     var ret = false;
+
+//     var eedge = this.get_edge(subject_id, object_id, predicate_id);
+//     if( eedge ){
+// 	ret = this.remove_edge_by_id(eedge.id());
+//     }
+
+//     return ret;
+// };
+
+/**
+ * Remove an edge to the graph.
+ * The edge as IDed.
+ *
+ * @param {String} edge_id - edge by ID
+ * @returns {Boolean} true if such an edge was found and deleted, false otherwise
+ */
+noctua_graph.prototype.remove_edge_by_id = function(eeid){
+    var ret = false;
+
+    if( this.core['edges'][eeid] ){
+
+	// Summon up the edge to properly remove it from the model.
+	var eedge = this.core['edges'][eeid];
+
+	// Remove the node itself from super.
+	ret = bbop_graph.prototype.remove_edge.call(this,
+						    eedge.subject_id(),
+						    eedge.object_id(),
+						    eedge.predicate_id());
+
+	// Main bit out.
+	delete this.core['edges'][eeid];
+
+	// And clean the maps.
+	var cid = this.core['edge2connector'][eeid];
+	delete this.core['edge2connector'][eeid];
+	delete this.core['connector2edge'][cid];
+    }
+
+    return ret;
+};
+
+/**
+ * Internally connect an edge to a connector ID
+ *
+ * TODO/BUG: Should use generic ID mapping rather than depending on
+ * jsPlumb thingamajunk.
+ *
+ * @deprecated
+ * @param {edge} eedge - edge
+ * @param {connector} connector - jsPlumb connector
+ */
+noctua_graph.prototype.create_edge_mapping = function(eedge, connector){
+    var eid = eedge.id();
+    var cid = connector.id;
+    this.core['edge2connector'][eid] = cid;
+    this.core['connector2edge'][cid] = eid;
+};
+
+/**
+ * Debugging text output function.
+ *
+ * Not sure what this is for anymore honestly...
+ *
+ * @deprecated
+ * @returns {String} a graph rep as a string
+ */
+noctua_graph.prototype.dump = function(){
+
+    //
+    var dcache = [];
+
+    each(this.get_nodes(), function(node, node_id){
+	var ncache = ['node'];
+	ncache.push(node.id());
+	dcache.push(ncache.join("\t"));
+    });
+
+    each(this.core['edges'], function(edge, edge_id){
+	var ecache = ['edge'];
+	ecache.push(edge.subject_id());
+	ecache.push(edge.predicate_id());
+	ecache.push(edge.object_id());
+	dcache.push(ecache.join("\t"));
+    });
+
+    return dcache.join("\n");
+};
+
+/**
+ * Merge another graph (addition) into the current graph. Includes the
+ * copying of annotations for the graph. This is an /additive/
+ * operation (e.g. annotations and other non-unique entities
+ * accumulate). Graph ID is /not/ copied.
+ *
+ * modified-p and inconsistent-p properties are copied from the the
+ * incoming graph (assuming that the update has more recent
+ * information).
+ *
+ * @param {graph} in_graph - the graph to merge in
+ * @returns {Boolean} if graph was loaded
+ */
+noctua_graph.prototype.merge_in = function(in_graph){
+    var anchor = this;
+
+    var ret = bbop_graph.prototype.merge_in.call(anchor, in_graph);
+
+    // Function to check if two annotations are the same.
+    function _is_same_ann(a1, a2){
+    	var ret = false;
+    	if( a1.key() === a2.key() &&
+    	    a1.value() === a2.value() &&
+    	    a1.value_type() === a2.value_type() ){
+    	    ret = true;
+    	}
+    	return ret;
+    }
+
+    // Merge in graph annotations.
+    var in_graph_anns = in_graph.annotations();
+    each(in_graph_anns, function(ann){
+    	// If there are no annotations that have the same KVT triple,
+    	// add a clone.
+    	if( anchor.get_annotations_by_filter( function(a){ return _is_same_ann(ann, a); } ).length === 0 ){
+    	    anchor.add_annotation(ann.clone());
+    	}
+    });
+
+    // Accept the signal that the merge in graph (update) has the
+    // correct modification and inconsistent information.
+    anchor._inconsistent_p = in_graph._inconsistent_p;
+    anchor._modified_p = in_graph._modified_p;
+
+    // Accept the signal that the merge in graph (update) has the
+    // correct validation/violation information.
+    // TODO: Ask @goodb what the semantics are for different
+    // signals when the reasoner are on--I'm assuming we clobber
+    // here.
+    anchor._violations = [];
+    each(in_graph._violations, function(violation){
+	anchor._violations.push(violation.clone());
+    });
+    anchor._valid_p = in_graph._valid_p;
+    anchor._valid_owl_p = in_graph._valid_owl_p;
+    anchor._valid_shex_p = in_graph._valid_shex_p;
+
+    return ret;
+};
+
+/**
+ * Merge another graph into the current graph, with special overwrite
+ * rules. In essence, this could be used when trying to simulate a
+ * rebuild even though you got merge data.
+ *
+ * Annotations in any top-level item (graph, node, edge), or lack
+ * thereof, from the incoming graph is preferred.
+ *
+ * All extant edges and nodes in the incoming graph are clobbered.
+ *
+ * The incoming graph is considered to be "complete", so any edges
+ * where both the source and sink are in the incoming graph are
+ * considered to be the only edges between those node.
+ *
+ * Graph ID is /not/ copied.
+ *
+ * Beware that you're in the right folded mode.
+ *
+ * @param {graph} in_graph - the graph to merge in
+ * @returns {Boolean} if graph was loaded
+ */
+noctua_graph.prototype.merge_special = function(in_graph){
+    var anchor = this;
+
+    // Since we can actually legally have an edge delete in the
+    // merge, let's go ahead and cycle through the "complete"
+    // graph and toss edges from individuals involved in the
+    // merge.
+    var involved_node = {};
+    each(in_graph.all_nodes(), function(node){
+	involved_node[node.id()] = true;
+    });
+    // Okay, now get rid of all edges that are defined by the
+    // involved nodes.
+    each(anchor.all_edges(), function(edge){
+	if(involved_node[edge.subject_id()] && involved_node[edge.object_id()]){
+	    anchor.remove_edge_by_id(edge.id());
+	}
+    });
+
+    // Blitz our old annotations as all new will be incoming (and
+    // the merge just takes the superset). Will be fine with fix:
+    // https://github.com/geneontology/minerva/issues/5
+    anchor.annotations([]);
+
+    var ret = anchor.merge_in(in_graph);
+    return ret;
+};
+
+/**
+ * DEPRECATED
+ *
+ * This uses a subgraph to update the contents of the current
+ * graph. The update graph is considered to be an updated complete
+ * self-contained subsection of the graph, clobbering nodes, edges,
+ * and the graph annotations. In the case of edges, all edges for the
+ * incoming nodes are deleted, and the ones described in the incoming
+ * graph are added (again, update).
+ *
+ * For example: you can think of it like this: if we have a graph:
+ *  A, B, C, and A.1, where A, B, and C are nodes and A.1 is an annotation for A.
+ * And we have an argument subgraph:
+ *  A, B, and edge (A,B), and A.2, B.1.
+ * The final graph would be:
+ *  A, B, C and edge (A,B), and A.2, B.1.
+ *
+ * Essentially, any entity in the new graph clobbers the "old"
+ * version; nodes not mentioned are left alone, the subgraph edges are
+ * assumed to be complete with reference to the contained nodes. This
+ * can express removal of things like annotations and sometimes edges,
+ * but not of nodes and edges not contained in within the subgraph.
+ *
+ * See the unit tests for examples.
+ *
+ * Be careful of what happens when using with the various loaders as
+ * the contents of top-level entities can be very different--you
+ * probably want to apply the right loader first.
+ *
+ * @deprecated
+ * @param {graph} in_graph - the graph to update with
+ * @returns {Boolean} if graph was loaded
+ */
+noctua_graph.prototype.update_with = function(update_graph){
+    var anchor = this;
+
+    // Prefer the new graph annotations by nuking the old.
+    anchor._annotations = [];
+    var update_graph_anns = update_graph.annotations();
+    each(update_graph_anns, function(ann){
+    	anchor.add_annotation(ann.clone());
+    });
+
+    // Next, look at individuals/nodes for addition or updating.
+    var updatable_nodes = {};
+    each(update_graph.all_nodes(), function(ind){
+	// Update node by clobbering. This is preferred since deleting
+	// it would mean that all the connections would have to be
+	// reconstructed as well.
+	var update_node = anchor.get_node(ind.id());
+	if( update_node ){
+	    //console.log('update node: ' + ind.id());
+	}else{
+	    //console.log('add new node' + ind.id());
+	}
+	// Mark as a modified node.
+	updatable_nodes[ind.id()] = true;
+	// Add new node to edit core.
+	anchor.add_node(ind.clone());
+    });
+
+    // Now look at edges (by individual) for purging and
+    // reinstating--no going to try and update edges, just clobber.
+    each(update_graph.all_nodes(), function(source_node){
+    	//console.log('looking at node: ' + source_node.id());
+
+    	// Look up what edges it has in /core/, as they will be the
+    	// ones to update.
+    	var snid = source_node.id();
+    	var src_edges = anchor.get_edges_by_subject(snid);
+
+    	// Delete all edges for said node in model. We cannot
+    	// (apparently?) go from connection ID to connection easily,
+    	// so removing from UI is a separate step.
+    	each(src_edges, function(src_edge){
+    	    // Remove from model.
+    	    var removed_p = anchor.remove_edge_by_id(src_edge.id());
+    	    //console.log('remove edge (' + removed_p + '): ' + src_edge.id());
+    	});
+    });
+
+    // All edges should have IDs, so get them out of the graph if they
+    // are incoming.
+    each(update_graph.all_edges(), function(edge){
+	var in_id = edge.id();
+	anchor.remove_edge_by_id(in_id);
+	anchor.add_edge(edge.clone());
+    });
+
+    return true;
+};
+
+/**
+ * Load minerva data response.
+ *
+ * TODO: inferred individuals
+ *
+ * @param {Object} the "data" portion of a Minerva graph-related response.
+ * @returns {Boolean} if data was loaded
+ */
+noctua_graph.prototype.load_data_basic = function(data){
+    var anchor = this;
+
+    var ret = false;
+
+    if( data ){
+
+	// Add the graph metadata.
+	var graph_id = data['id'] || null;
+	var graph_anns = data['annotations'] || [];
+	if( graph_id ){ anchor.id(graph_id); }
+	if( ! us.isEmpty(graph_anns) ){
+	    each(graph_anns, function(ann_kv_set){
+		var na = new annotation(ann_kv_set);
+		anchor.add_annotation(na);
+	    });
+	}
+
+	// Add the additional metadata.
+	if( typeof(data['inconsistent-p']) !== 'undefined' ){
+	    anchor._inconsistent_p = data['inconsistent-p'];
+	}
+	if( typeof(data['modified-p']) !== 'undefined' ){
+	    anchor._modified_p = data['modified-p'];
+	}
+
+	// Validation/violation information. Currently, this will only
+	// be entered if the reasoner is on.
+	if( typeof(data['validation-results']) !== 'undefined' &&
+	    us.isObject(data['validation-results']) ){
+
+	    var vres = data['validation-results'];
+
+	    // Top level.
+	    if( us.isBoolean(vres['is-conformant']) ){
+		if( vres['is-conformant'] === true ){
+		    anchor._valid_p = true;
+		}else if( vres['is-conformant'] === false ){
+		    anchor._valid_p = false;
+		}
+	    }
+
+	    // OWL.
+	    if( vres['owl-validation'] && us.isObject(vres['owl-validation']) ){
+		if( vres['owl-validation']['is-conformant'] === true ){
+		    anchor._valid_owl_p = true;
+		}else if( vres['owl-validation']['is-conformant'] === false ){
+		    anchor._valid_owl_p = false;
+		}
+	    }
+
+	    // ShEx.
+	    if( vres['shex-validation'] && us.isObject(vres['shex-validation'])){
+		if( vres['shex-validation']['is-conformant'] === true ){
+		    anchor._valid_shex_p = true;
+		}else if( vres['shex-validation']['is-conformant'] === false ){
+		    anchor._valid_shex_p = false;
+		}
+	    }
+
+	    // Collect into violation objects; currently just ShEx.
+	    if( vres['shex-validation'] &&
+		us.isObject(vres['shex-validation']) &&
+		us.isArray(vres['shex-validation']['violations']) ){
+
+		var violations = vres['shex-validation']['violations'] || [];
+		each(violations, function(raw_v){
+		    var new_v = new violation(raw_v);
+		    anchor._violations.push(new_v);
+		});
+	    }
+	}
+
+	// Easy facts.
+	var facts = data['facts'];
+	each(facts, function(fact){
+	    anchor.add_edge_from_fact(fact);
+	});
+
+	// Build the structure of the graph in the most obvious way.
+	var inds = data['individuals'];
+	each(inds, function(ind){
+	    anchor.add_node_from_individual(ind);
+	});
+
+	ret = true;
+    }
+
+    return ret;
+};
+
+/**
+ * Extract all of the evidence seeds from the graph--nodes and edges.
+ *
+ * An evidence seed is a: 1) real node in the graph that 2) is
+ * referenced by the value of a node or edge special evidence
+ * annotation.
+ *
+ * @returns {Object} a map of seeds (by id) to their referencing enity {node} or {edge}
+ */
+noctua_graph.prototype.extract_evidence_seeds = function(){
+    var anchor = this;
+
+    // Take and, and see if it is an evidence reference.
+    function is_iri_ev_p(ann){
+	var ret = false;
+	if( ann.key() === 'evidence' && ann.value_type() === 'IRI' ){
+	    ret = true;
+	}
+	return ret;
+    }
+
+    // For any node, look at all of the annotations, and fold in
+    // ones that 1) pass the test and 2) reference a singleton
+    // node.
+    var seeds = {}; // collect all possibilities here
+    function pull_seeds(entity, test_p){
+	each(entity.annotations(), function(ann){
+
+	    //console.log(ann.key(), ann.value_type(), ann.value());
+
+	    // Is it an evidence annotation.
+	    if( ! test_p(ann) ){
+		// Skip.
+		//console.log('skip folding with failed test');
+	    }else{
+		//console.log('start folding with passed test');
+
+		// If so, and the individual in question exists, it is
+		// the jumping off point for the evidence folding
+		// subgraph.
+		var ref_node_id = ann.value();
+		var ref_node = anchor.get_node(ref_node_id);
+		if( ref_node ){
+		    seeds[ref_node_id] = entity;
+		}
+	    }
+	});
+    }
+
+    // Cycle through everything and collect them.
+    each(anchor.all_nodes(), function(node){
+	pull_seeds(node, is_iri_ev_p);
+    });
+    each(anchor.all_edges(), function(edges){
+	pull_seeds(edges, is_iri_ev_p);
+    });
+
+    return seeds;
+};
+
+/**
+ * Extract the entire super clique subgraph for an entity.
+ *
+ * The ID for the graph will be the ID of the seed node.
+ *
+ * BUG/WARNING: The clique actually needs to use the walker rather
+ * than the anc/desc functions it uses now.
+ *
+ * @param {String} node_id the ID of the see node in an evidence clique
+ * @returns {graph} a list of found seeds as {node} ids
+ */
+noctua_graph.prototype.get_evidence_clique = function(node_id){
+    var anchor = this;
+
+    // Create the clique by grabbing all nodes and creating a walkable
+    // neighborhood.
+    var up = anchor.get_ancestor_subgraph(node_id);
+    //console.log("UP: ", up);
+    var down = anchor.get_descendent_subgraph(node_id);
+    //console.log("DOWN: ", down);
+    up.merge_in(down);
+
+    up.id(node_id);
+
+    var ret = up;
+    return ret;
+};
+
+/**
+ * Extract an evidence subclique starting at a seed node.
+ *
+ * A subclique is a subgraph within a clique that represents a piece
+ * of evidence, and may overlap with other pieces of evidence.
+ *
+ * The ID for the graph will be the ID of the seed node.
+ *
+ * Returns a clone.
+ *
+ * TODO: More to do as we expand what the evidence subgraphs look
+ * like.
+ *
+ * @param {String} node_id the ID of the seed node in an evidence clique - it is *assumed* that this is a legit seed node id
+ * @returns {graph|null} a list of found seeds as {node} ids
+ */
+noctua_graph.prototype.get_evidence_subclique = function(node_id){
+    var anchor = this;
+
+    var ret = null;
+
+    // Must have a seed to start.
+    var seed_node = anchor.get_node(node_id);
+    if( seed_node ){
+
+	// Start a new graph here. If this is the traditional simple
+	// GO model, we also stop here.
+	var ret_graph = anchor.create_graph();
+	ret_graph.id(node_id);
+	ret_graph.add_node(seed_node.clone());
+
+	// For more complicated PMID evidence, we need to walk a
+	// little deeper.
+	// Add the kids...
+	var kids = anchor.get_child_nodes(seed_node.id(), 'IAO:0000136');
+	if( ! us.isEmpty(kids) ){
+	    each(kids, function(kid){
+		var klone = kid.clone();
+		ret_graph.add_node(klone);
+	    });
+	    // ...and create new edges.
+	    var keds = anchor.get_child_edges(seed_node.id(), 'IAO:0000136');
+	    each(keds, function(ked){
+		var klone = ked.clone();
+		ret_graph.add_edge(klone);
+	    });
+
+	    // TODO: Dig down deeper from here for publication.
+	}
+
+	// TODO: Dig down deeper from here for non-publication.
+
+	// This is what we'll return.
+	ret = ret_graph;
+    }
+
+    return ret;
+};
+
+/**
+ * Fold the evidence individuals into the edges and nodes that
+ * reference them under the referenced_subgraph functions.
+ *
+ * Currently, a single pass is run to fold evidence subgraphs
+ * (sometimes containing a single node) into other nodes/edges as
+ * referenced subgraphs. However, additional passes can very easily be
+ * added to fold away references to references as long as a matching
+ * function is provided.
+ *
+ * @returns {Boolean} if data was loaded
+ */
+noctua_graph.prototype.fold_evidence = function(){
+    var anchor = this;
+
+    var ret = false;
+
+    // We are going to fold by clique.
+    var seeds = anchor.extract_evidence_seeds();
+    //console.log('seeds', us.keys(seeds));
+
+    // Get the cliques (super-neighborhood evidence) and get a map of
+    // what seeds are in each clique. Instead of comparing cliques to
+    // eliminate dupes (it's possible to have shared structure), we
+    // just keep checking the seeds, marking the ones that we've seen
+    // so we don't check again.
+    //
+    // This section produces a clique map and a clique to sed map.
+    //
+    var cliques = {}; // clique_id->clique
+    var clique_seed_map = {}; // clique_id->{seeds->true, in->true, clique->true}
+    var skippable_seeds = {}; // once we see a seed, we can skip it afterwards
+    each(seeds, function(referncing_entity, seed_id){
+	//console.log('seed_id', seed_id);
+	if( ! skippable_seeds[seed_id] ){ // skip uneeded ones
+
+	    // Get clique.
+	    var clique = anchor.get_evidence_clique(seed_id);
+	    var clique_id = clique.id();
+	    //console.log(' clique_id', clique_id);
+	    //console.log(' clique', clique);
+
+	    // Ready clique map.
+	    clique_seed_map[clique_id] = {};
+
+	    //
+	    each(seeds, function(check_referencing_entity, check_seed_id){
+		if( ! skippable_seeds[check_seed_id] ){ // skip uneeded ones
+		    //console.log(' pass', check_seed_id);
+
+		    //
+		    if( clique.get_node(check_seed_id) ){
+			//console.log(' in clique:', check_seed_id);
+
+			// Add seed to map and skippable.
+			clique_seed_map[clique_id][check_seed_id] = true;
+			skippable_seeds[check_seed_id] = true;
+			cliques[clique_id] = clique;
+			// console.log('seed',check_seed_id,
+			// 	    '\n in clique',clique_id);
+		    }else{
+			// Pass.
+			// console.log('seed',check_seed_id,
+			// 	    'not in clique',clique_id);
+		    }
+		}
+	    });
+	}
+    });
+
+    //console.log('cliques', cliques);
+    //console.log('cliques', us.keys(cliques));
+    //console.log('clique_seed_map', clique_seed_map);
+
+    // Okay, we will do the folding on a clique-by-clique basis. See
+    // the top of the file for rules.
+    each(cliques, function(clique, clique_id){
+
+	//console.log('clique_id', clique_id);
+
+	// Nodes in the clique.
+	var clique_nodes = {};
+	each(clique.all_nodes(), function(cn){
+	    var cnid = cn.id();
+	    clique_nodes[cnid] = true;
+	});
+
+	// Collect the subcliques for every clique.
+	var contained_seed_map = clique_seed_map[clique_id];
+	//console.log('csm', contained_seed_map);
+	var subcliques = {};
+	each(contained_seed_map, function(bool, seed_id){
+
+	    var subclique = anchor.get_evidence_clique(seed_id);
+	    //console.log(subclique);
+
+	    // Add to cache of subcliques.
+	    subcliques[seed_id] = subclique;
+
+	    // Mark out all of the clique_nodes seen.
+	    each(subclique.all_nodes(), function(sub_node){
+		var snid = sub_node.id();
+		if( clique_nodes[snid] ){
+		    delete clique_nodes[snid];
+		}
+	    });
+	});
+
+	//console.log('clique_nodes', clique_nodes);
+	//console.log('subcliques', subcliques);
+
+	// Okay, if the clique_nodes map is empty, that means it is
+	// completely covered by the subcliques and can be removed.
+	if( ! us.isEmpty(clique_nodes) ){
+	    //console.log(' cannot fold clique due to maigo no node');
+	}else{
+	    // Add subcliques to initial referring nodes.
+	    each(subcliques, function(subclique, seed_id){
+		// Make sure that we fold into the original node of
+		// the original graph.
+		var origin_entity = seeds[seed_id]; // still a copy
+		if( ! origin_entity ){
+		    // console.log('skip addition (possibly edge uuid)');
+		    // console.log('skip addition over (A)', seed_id);
+		    // console.log('skip addition over (B)',
+		    // 		origin_node_clone_maybe.id());
+		}else{
+		    // Since origin_entity is a copy, we'll modify it
+		    // and re-add it to the graph to make change
+		    // permanent.
+		    origin_entity.add_referenced_subgraph(subclique);
+		    // clobber non-ref version
+		    var entity_is =  bbop.what_is(origin_entity);
+		    //console.log(entity_is, entity_is);
+		    if( entity_is === 'bbop-graph-noctua.node' ){
+			anchor.add_node(origin_entity);
+		    }else if( entity_is === 'bbop-graph-noctua.edge' ){
+			anchor.add_edge(origin_entity);
+		    }else{
+			// Very Bad.
+			log('ERROR: attempt to clobber unknown entity');
+		    }
+		}
+	    });
+
+	    // Disolve the entire clique from graph, depending on edge
+	    // to auto-disolve.
+	    each(clique.all_nodes(), function(removable_cn, cni){
+		//console.log('remove', cni , removable_cn.id());
+		//console.log(anchor.remove_node(removable_cn.id(), true));
+		anchor.remove_node(removable_cn.id(), true);
+	    });
+	}
+    });
+
+    ret = true;
+
+    return ret;
+};
+
+/**
+ * In addition to everything we did for {fold_evidence},
+ * we're going to search for nodes that have enabled_by and/or
+ * occurs_in (or any other specified relation) targets (that are
+ * themselves leaves) fold them in to the contained subgraph item, and
+ * remove them from the top-level graph.
+ *
+ * TODO: inferred individuals
+ *
+ * @param {Array} relation_list of relations (as strings) to scan for for collapsing
+ * @param {Array} relation_reverse_list of relations (as strings) to scan for for collapsing in the opposite direction.
+ * @returns {Boolean} if data was loaded
+ */
+noctua_graph.prototype.fold_go_noctua = function(relation_list,
+						 relation_reverse_list){
+    var anchor = this;
+
+    // Start out with the evidence folded graph.
+    var ret = anchor.fold_evidence();
+    if( ! ret ){ return false; } // Early bail on bad upstream.
+
+    // It is foldable if it is a root node (re: opposite of leaf--only
+    // target) and if it only has the one child (no way out--re: collapsible ).
+    function _foldable_p(node){
+	var ret = false;
+	// console.log("  " + dd(node.id()));
+	if( anchor.is_root_node(node.id()) &&
+	    ! node.subgraph() && // cannot fold if already folded into
+	    anchor.get_child_nodes(node.id()).length === 1 ){
+		// console.log("    Y root_p: " +
+		// 	    anchor.is_root_node(node.id()) +
+		// 	    ";  kids: " +
+		// 	    anchor.get_child_nodes(node.id()).length);
+		ret = true;
+	    }else{
+		// console.log("    N root_p: " +
+		// 	    anchor.is_root_node(node.id()) +
+		// 	    ";  kids: " +
+		// 	    anchor.get_child_nodes(node.id()).length);
+	    }
+	return ret;
+    }
+
+    // It is reverse foldable if it is a leaf node (re: opposite of
+    // root--only source) and if it only has the one child (no way
+    // out--re: collapsible ).
+    function _reverse_foldable_p(node){
+	var ret = false;
+	if( anchor.is_leaf_node(node.id()) &&
+	    ! node.subgraph() && // cannot fold if already folded into
+	    anchor.get_parent_nodes(node.id()).length === 1 ){
+		//console.log("is foldable: " + node.id());
+		ret = true;
+	    }else{
+		//console.log("not foldable: " + node.id());
+	    }
+	// console.log("  leaf_p: " + anchor.is_leaf_node(node.id()) +
+	// 	    ";  parents: " + anchor.get_parent_nodes(node.id()).length);
+	return ret;
+    }
+
+    // Okay, first scan all nodes for our pattern.
+    // each(anchor.all_nodes(), function(pattern_seed_indv){
+    // Temporarily enforce an ordering so we can debug/have consistent
+    // results.
+    var todo_nodes = anchor.all_nodes();
+    todo_nodes = todo_nodes.sort(function(a,b){
+	//console.log(a.id()+' vs. '+ b.id() +': '+a.id().localeCompare(b.id()));
+	return a.id().localeCompare(b.id());
+    });
+    each(todo_nodes, function(pattern_seed_indv){
+	//console.log( dd(pattern_seed_indv.id()) );
+
+	var pattern_seed_id = pattern_seed_indv.id();
+
+	// The possible base subgraph (seeding with current node--note
+	// the clone so we don't have infinite recursion) we might
+	// capture.
+	var subgraph = anchor.create_graph();
+	subgraph.add_node(pattern_seed_indv.clone());
+
+	// Fold checking is independent of reverse or not.
+	var fold_occurred_p = false;
+
+	// Check a set of relations for completeness.
+	var collapsable_relations = relation_list || [];
+	each(collapsable_relations, function(relation){
+
+	    var parents = anchor.get_parent_nodes(pattern_seed_id, relation);
+	    each(parents, function(parent){
+
+		if( _foldable_p(parent) ){
+		    fold_occurred_p = true;
+
+		    // Preserve it and its edge in the new subgraph.
+		    var p = parent.clone();
+		    // if( p.subgraph() ){
+		    // 	console.log('  has SUB');
+		    // }
+		    subgraph.add_node(p);
+		    var eta = anchor.get_edge(pattern_seed_id, p.id(), relation);
+		    subgraph.add_edge(eta.clone());
+		    // subgraph.report_state();
+
+		    // Remove same from the original graph, edge will be
+		    // destroyed in the halo.
+		    anchor.remove_node(parent.id(), true);
+		    // console.log('  *destroyed: ' + dd(parent.id()) );
+		}
+	    });
+	});
+
+	// ...and now the other way.
+	var collapsable_reverse_relations = relation_reverse_list || [];
+	each(collapsable_reverse_relations, function(relation){
+
+	    var children = anchor.get_child_nodes(pattern_seed_id, relation);
+	    each(children, function(child){
+
+		if( _reverse_foldable_p(child) ){
+		    fold_occurred_p = true;
+
+		    // Preserve it and its edge in the new subgraph.
+		    subgraph.add_node(child.clone());
+		    subgraph.add_edge( // we know it's just one from above
+			anchor.get_child_edges(pattern_seed_id,
+					       relation)[0].clone());
+
+		    // Remove same from the original graph, edge will
+		    // be destroyed in the halo.
+		    anchor.remove_node(child.id(), true);
+		}
+	    });
+	});
+
+	// A usable folding subgraph only occurred when the are more
+	// than 1 node in it; i.e. we actually actually added things
+	// to our local subgraph and removed them from the master
+	// graph.
+	if( fold_occurred_p ){
+	    // console.log('slurpable subgraph ('+ subgraph.all_nodes().length +
+	    // 		') for: ' + pattern_seed_id);
+	    pattern_seed_indv.subgraph(subgraph);
+	}
+
+    });
+
+    return ret;
+};
+
+/**
+ * Essentially, undo anything that could be done in a folding
+ * step--return the graph to its most expanded form.
+ *
+ * @param {Object} [incoming_graph] subgraph to unfold into the calling graph (default behaviour would be calling itself; only really used internally by this method for recursion)
+ * @returns {Boolean} if unfolded (should always be true)
+ */
+noctua_graph.prototype.unfold = function(incoming_graph){
+    var anchor = this;
+
+    // If not a recursive, we will operate on ourselves.
+    if( ! incoming_graph ){
+    	incoming_graph = anchor;
+    }
+
+    // For any entity, remove its referenced individuals and re-add
+    // them to the graph.
+    function _unfold_subgraph(sub){
+
+	// Restore to graph.
+	// console.log('   unfold # (' + sub.all_nodes().length + ', ' +
+	// 	    sub.all_edges().length + ')');
+	each(sub.all_nodes(), function(node){
+	    anchor.add_node(node);
+	});
+	each(sub.all_edges(), function(edge){
+	    anchor.add_edge(edge);
+	});
+    }
+
+    // Apply to all nodes.
+    each(incoming_graph.all_nodes(), function(node){
+
+	// Get references (ev).
+	var ref_graphs = node.referenced_subgraphs();
+
+	// Restore to graph.
+	each(ref_graphs, function(sub){
+	    _unfold_subgraph(sub);
+	});
+
+	// Remove references.
+	node.referenced_subgraphs([]);
+
+	// Now that they've been removed (to help prevent loops) try
+	// and recur.
+	each(ref_graphs, function(sub){
+	    anchor.unfold(sub);
+	});
+
+	// Repeat with any absorbed subgraph.
+	var asub = node.subgraph();
+	if( asub ){
+	    _unfold_subgraph(asub);
+	    node.subgraph(null); // eliminate after it has been re-added
+	    // Recur on any found subgraphs, safer since the elimination.
+	    anchor.unfold(asub);
+	}
+
+    });
+
+    // Apply to all edges.
+    each(incoming_graph.all_edges(), function(edge){
+
+	// Get references (ev).
+	var ref_graphs = edge.referenced_subgraphs();
+
+	// Restore to graph.
+	each(ref_graphs, function(sub){
+	    _unfold_subgraph(sub);
+	});
+
+	// Remove references.
+	edge.referenced_subgraphs([]);
+
+	// Now that they've been removed, try and recur (to help
+	// prevent loops).
+	each(ref_graphs, function(sub){
+	    anchor.unfold(sub);
+	});
+    });
+
+    // Revisit if we want something meaningful out of here.
+    var retval = true;
+    return retval;
+};
+
+/**
+ * Provide a verbose report of the current state of the graph and
+ * subgraphs. Writes using console.log; only to be used for debugging.
+ *
+ * @returns {null} just the facts
+ */
+noctua_graph.prototype.report_state = function(incoming_graph, indentation){
+    var anchor = this;
+
+    // If not a recursive, we will operate on ourselves.
+    if( ! incoming_graph ){
+    	incoming_graph = anchor;
+    }
+
+    // Start with no indentation.
+    if( typeof(indentation) === 'undefined' ){
+    	indentation = 0;
+    }
+
+    // Collect spacing for this indentation level of logging.
+    var spacing = '';
+    for( var i = 0; i < indentation; i++ ){
+	spacing += '   ';
+    }
+    function ll(str){
+	log(spacing + str);
+    }
+    function short(str){
+	return str.substr(str.length - 16);
+    }
+
+    // Restore to graph.
+    var gid = incoming_graph.id() || '(anonymous graph)';
+    ll(gid);
+    ll(' entities # (' + incoming_graph.all_nodes().length +
+       ', ' + incoming_graph.all_edges().length + ')');
+
+    // Show node information, arbitrary, but fixed, order.
+    each(incoming_graph.all_nodes().sort(function(a,b){
+	if( a.id() > b.id() ){
+	    return 1;
+	}else if( a.id() < b.id() ){
+	    return -1;
+	}
+	return 0;
+    }), function(node){
+	ll(' node: ' + dd(node.id()));
+
+	// Subgraph.
+	var subgraph = node.subgraph();
+	if( subgraph ){
+	    ll('  subgraph: ');
+	    anchor.report_state(subgraph, indentation +1);
+	}
+
+	// Refs.
+	var ref_graphs = node.referenced_subgraphs();
+	if( ref_graphs.length > 0 ){
+	    ll('  references: ');
+	    each(ref_graphs, function(sub){
+		anchor.report_state(sub, (indentation +1));
+	    });
+	}
+    });
+
+    // Show edge information, arbitrary, but fixed, order.
+    each(incoming_graph.all_edges().sort(function(a,b){
+	if( a.id() > b.id() ){
+	    return 1;
+	}else if( a.id() < b.id() ){
+	    return -1;
+	}
+	return 0;
+    }), function(edge){
+	var s = dd(edge.subject_id());
+	var o = dd(edge.object_id());
+	var p = dd(edge.predicate_id());
+	//ll(' edge: ' + edge.id());
+	ll(' edge: ' + s + ', ' + o + ': ' + p);
+
+	// Refs.
+	var ref_graphs = edge.referenced_subgraphs();
+	if( ref_graphs.length > 0 ){
+	    ll('  references: ');
+	    each(ref_graphs, function(sub){
+		anchor.report_state(sub, (indentation +1));
+	    });
+	}
+    });
+
+    if( ! us.isEmpty(incoming_graph._os_table) ){
+	log(spacing + 'OS:', incoming_graph._os_table);
+    }
+    if( ! us.isEmpty(incoming_graph._so_table) ){
+	log(spacing + 'SO:', incoming_graph._so_table);
+    }
+    if( ! us.isEmpty(incoming_graph._predicates) ){
+	log(spacing + 'PRED:', incoming_graph._predicates);
+    }
+
+    return null;
+};
+
+///
+/// Node subclass and overrides.
+///
+
+var bbop_node = bbop_model.node;
+/**
+ * Sublcass of bbop-graph.node for use with Noctua ideas and concepts.
+ *
+ * @constructor
+ * @see module:bbop-graph
+ * @alias node
+ * @param {String} [in_id] - new id; otherwise new unique generated
+ * @param {String} [in_label] - node "label"
+ * @param {Array} [in_types] - list of Objects or strings--anything that can be parsed by class_expression
+ * @param {Array} [in_inferred_types] - list of Objects or strings--anything that can be parsed by class_expression
+ * @returns {this}
+ */
+function noctua_node(in_id, in_label, in_types, in_root_types, in_inferred_types, in_inferred_types_with_all){
+    bbop_node.call(this, in_id, in_label);
+    this._is_a = 'bbop-graph-noctua.node';
+    var anchor = this;
+
+    // Let's make this an OWL-like world.
+    this._types = [];
+    this._id2type = {}; // contains map to both types and inferred types
+    this._root_types = [];
+    this._inferred_types = [];
+    this._inferred_types_with_all = [];
+    this._annotations = [];
+    this._referenced_subgraphs = [];
+    this._embedded_subgraph = null;
+
+    // Incoming ID or generate ourselves.
+    if( typeof(in_id) === 'undefined' ){
+	this._id = bbop.uuid();
+    }else{
+	this._id = in_id;
+    }
+
+    // Roll in any types that we may have coming in.
+    if( us.isArray(in_types) ){
+	each(in_types, function(in_type){
+	    var new_type = new class_expression(in_type);
+	    anchor._id2type[new_type.id()] = new_type;
+	    anchor._types.push(new class_expression(in_type));
+	});
+    }
+    // Same with root types.
+    if( us.isArray(in_root_types) ){
+	each(in_root_types, function(in_root_type){
+	    var new_root_type = new class_expression(in_root_type);
+	    anchor._id2type[new_root_type.id()] = new_root_type;
+	    anchor._root_types.push(new class_expression(in_root_type));
+	});
+    }
+    // Same with inferred types.
+    if( us.isArray(in_inferred_types) ){
+	each(in_inferred_types, function(in_inferred_type){
+	    var new_type = new class_expression(in_inferred_type);
+	    anchor._id2type[new_type.id()] = new_type;
+	    anchor._inferred_types.push(new class_expression(in_inferred_type));
+	});
+    }
+    // Same with inferred types with all.
+    if( us.isArray(in_inferred_types_with_all) ){
+	each(in_inferred_types_with_all, function(in_inferred_type_with_all){
+	    var new_type = new class_expression(in_inferred_type_with_all);
+	    anchor._id2type[new_type.id()] = new_type;
+	    anchor._inferred_types_with_all.push(new class_expression(in_inferred_type_with_all));
+	});
+    }
+}
+bbop.extend(noctua_node, bbop_node);
+
+/**
+ * Get a fresh new copy of the current node (using bbop.clone for
+ * metadata object).
+ *
+ * @returns {node} node
+ */
+noctua_node.prototype.clone = function(){
+    var anchor = this;
+
+    // Fresh.
+    var new_clone = new noctua_node(anchor.id(), anchor.label(), anchor.types(),
+				    anchor.root_types(),
+				    anchor.inferred_types(),
+				    anchor.inferred_types_with_all());
+
+    // Base class stuff.
+    new_clone.type(this.type());
+    new_clone.metadata(bbop.clone(this.metadata()));
+
+    // Transfer over the new goodies, starting with annotations and
+    // referenced individuals.
+    each(anchor._annotations, function(annotation){
+	new_clone._annotations.push(annotation.clone());
+    });
+    each(anchor._referenced_subgraphs, function(sub){
+	new_clone._referenced_subgraphs.push(sub.clone());
+    });
+
+    // Embedded subgraph.
+    if( anchor._embedded_subgraph ){
+	new_clone._embedded_subgraph = anchor._embedded_subgraph.clone();
+    }else{
+	new_clone._embedded_subgraph = null;
+    }
+
+    return new_clone;
+};
+
+/**
+ * Get current types; replace current types.
+ *
+ * Parameters:
+ * @returns {Array} array of types
+ */
+noctua_node.prototype.types = function(){
+    var anchor = this;
+    return this._types;
+};
+
+/**
+ * Get current root types; replace current root types.
+ *
+ * Parameters:
+ * @returns {Array} array of types
+ */
+noctua_node.prototype.root_types = function(){
+    var anchor = this;
+    return this._root_types;
+};
+
+/**
+ * Get current inferred types; replace current inferred types.
+ *
+ * Parameters:
+ * @returns {Array} array of types
+ */
+noctua_node.prototype.inferred_types = function(){
+    var anchor = this;
+    return this._inferred_types;
+};
+
+/**
+ * Get current inferred types with all; replace current inferred types.
+ *
+ * Parameters:
+ * @returns {Array} array of types
+ */
+noctua_node.prototype.inferred_types_with_all = function(){
+    var anchor = this;
+    return this._inferred_types_with_all;
+};
+
+/**
+ * Add types to current types.
+ *
+ * Parameters:
+ * @param {Object} in_types - raw JSON type objects
+ * @param {Boolean} inferred_p - whether or not the argument types are inferred
+ * @returns {Boolean} t|f
+ */
+noctua_node.prototype.add_types = function(in_types, inferred_p){
+    var anchor = this;
+    var inf_p = inferred_p || false;
+
+    var ret = false;
+
+    if( us.isArray(in_types) ){
+	each(in_types, function(in_type){
+	    var new_type = new class_expression(in_type);
+	    anchor._id2type[new_type.id()] = new_type;
+	    if( ! inferred_p ){
+		anchor._types.push(new_type);
+	    }else{
+		anchor._inferred_types.push(new_type);
+		// And with_all, as it is a superset.
+		anchor._inferred_types_with_all.push(new_type);
+	    }
+
+	    ret = true; // return true if did something
+	});
+    }
+    return ret;
+};
+
+/**
+ * If extant, get the type by its unique identifier. This works for
+ * both inferred and non-inferred types generally.
+ *
+ * @param {String} type_id - type id
+ * @returns {type|null} type or null
+ */
+noctua_node.prototype.get_type_by_id = function(type_id){
+    var anchor = this;
+
+    var ret = null;
+    ret = anchor._id2type[type_id];
+
+    return ret;
+};
+
+/**
+ * Essentially, get all of the "uneditable" root types from that are
+ * not duplicated in the regular (editable) types listing.
+ *
+ * Returns originals.
+ *
+ * Note: the matching here is awful and should be redone (going by
+ * very lossy string rep).
+ *
+ * @returns {Array} of {class_expression}
+ */
+noctua_node.prototype.get_unique_root_types = function(){
+    var anchor = this;
+
+    var ret = [];
+
+    // Create a checkable representation of the types.
+    var type_cache = {};
+    each(anchor.types(), function(t){
+	type_cache[t.signature()] = true;
+    });
+
+    // Do a lookup.
+    each(anchor.root_types(), function(t){
+	if( ! type_cache[t.signature()] ){
+	    ret.push(t);
+	}
+    });
+
+    return ret;
+};
+
+/**
+ * Essentially, get all of the "uneditable" direct inferred types from
+ * the reasoner that are not duplicated in the regular (editable)
+ * types listing.
+ *
+ * Returns originals.
+ *
+ * Note: the matching here is awful and should be redone (going by
+ * very lossy string rep).
+ *
+ * @returns {Array} of {class_expression}
+ */
+noctua_node.prototype.get_unique_inferred_types = function(){
+    var anchor = this;
+
+    var ret = [];
+
+    // Create a checkable representation of the types.
+    var type_cache = {};
+    each(anchor.types(), function(t){
+	type_cache[t.signature()] = true;
+    });
+
+    // Do a lookup.
+    each(anchor.inferred_types(), function(t){
+	if( ! type_cache[t.signature()] ){
+	    ret.push(t);
+	}
+    });
+
+    return ret;
+};
+
+/**
+ * Essentially, get all (the complete closure in this case) of the
+ * "uneditable" inferred types from the reasoner that are not
+ * duplicated in the regular (editable) types listing.
+ *
+ * Returns originals.
+ *
+ * Note: the matching here is awful and should be redone (going by
+ * very lossy string rep).
+ *
+ * @returns {Array} of {class_expression}
+ */
+noctua_node.prototype.get_unique_inferred_types_with_all = function(){
+    var anchor = this;
+
+    var ret = [];
+
+    // Create a checkable representation of the types.
+    var type_cache = {};
+    each(anchor.types(), function(t){
+	type_cache[t.signature()] = true;
+    });
+
+    // Do a lookup.
+    each(anchor.inferred_types_with_all(), function(t){
+	if( ! type_cache[t.signature()] ){
+	    ret.push(t);
+	}
+    });
+
+    return ret;
+};
+
+/**
+ * Get/set the "contained" subgraph. This subgraph is still considered
+ * to be part of the graph, but is "hidden" under this node for most
+ * use cases except serialization.
+ *
+ * To put it another way, unless you specifically load this with a
+ * specialized loader, it will remain unpopulated. During
+ * serialization, it should be recursively walked and dumped.
+ *
+ * @param {graph|null} [subgraph] - the subgraph to "hide" inside this individual in the graph, or null to reset it
+ * @returns {graph|null} contained subgraph
+ */
+noctua_node.prototype.subgraph = function(subgraph){
+    if( typeof(subgraph) === 'undefined' ){
+	// Just return current state.
+    }else if( subgraph === null ){
+	// Reset state (and return).
+	this._embedded_subgraph = null;
+    }else if(bbop.what_is(subgraph) === 'bbop-graph-noctua.graph'){
+	// Update state (and return).
+	this._embedded_subgraph = subgraph;
+    }
+    return this._embedded_subgraph;
+};
+
+///
+/// Edge subclass and overrides.
+///
+
+var bbop_edge = bbop_model.edge;
+/**
+ * Sublcass of bbop-graph.edge for use with Noctua ideas and concepts.
+ *
+ * @constructor
+ * @see module:bbop-graph
+ * @alias edge
+ * @param {String} subject - required subject id
+ * @param {String} object - required object id
+ * @param {String} [predicate] - preidcate id; if not provided, will use defined default (you probably want to provide one--explicit is better)
+ * @returns {this}
+ */
+function noctua_edge(subject, object, predicate){
+    bbop_edge.call(this, subject, object, predicate);
+    this._is_a = 'bbop-graph-noctua.edge';
+
+    // Edges are not completely anonymous in this world.
+    this._id = bbop.uuid();
+    this._predicate_label = null;
+
+    this._annotations = [];
+    this._referenced_subgraphs = [];
+}
+bbop.extend(noctua_edge, bbop_edge);
+
+/**
+ * Get a fresh new copy of the current edge--no shared structure.
+ *
+ * @returns {edge} - new copy of edge
+ */
+noctua_edge.prototype.clone = function(){
+    var anchor = this;
+
+    // Fresh.
+    var new_clone = new noctua_edge(anchor.subject_id(),
+				    anchor.object_id(),
+				    anchor.predicate_id());
+
+    // Same id.
+    new_clone._id = anchor._id;
+    new_clone._predicate_label = anchor._predicate_label;
+
+    // Base class stuff.
+    new_clone.default_predicate = anchor.default_predicate;
+    new_clone.type(anchor.type());
+    new_clone.metadata(bbop.clone(anchor.metadata()));
+
+    // Transfer over the new goodies.
+    each(anchor._annotations, function(annotation){
+	new_clone._annotations.push(annotation.clone());
+    });
+    each(anchor._referenced_subgraphs, function(ind){
+	new_clone._referenced_subgraphs.push(ind.clone());
+    });
+
+    return new_clone;
+};
+
+/**
+ * Access to the immutable "id".
+ *
+ * @returns {String} string
+ */
+noctua_edge.prototype.id = function(){
+    return this._id;
+ };
+
+/**
+ * Get/set "source" of edge.
+ *
+ * @deprecated
+ * @param {String} [value] - string
+ * @returns {String} string
+ */
+noctua_edge.prototype.source = function(value){
+    if(value){ this._subject_id = value; }
+    return this._subject_id;
+};
+
+/**
+ * Get/set "target" of edge.
+ *
+ * @deprecated
+ * @param {String} [value] - string
+ * @returns {String} string
+ */
+noctua_edge.prototype.target = function(value){
+    if(value){ this._object_id = value; }
+    return this._object_id;
+};
+
+/**
+ * Get/set "relation" of edge.
+ *
+ * @deprecated
+ * @param {String} [value] - string
+ * @returns {String} string
+ */
+noctua_edge.prototype.relation = function(value){
+    if(value){ this._predicate_id = value; }
+    return this._predicate_id;
+};
+
+/**
+ * Access to the mutable "label" for the edge.
+ *
+ * @param {String} [value] - lbl
+ * @returns {String|null} string
+ */
+noctua_edge.prototype.label = function(lbl){
+
+    if( lbl === null || typeof(lbl) === 'string' ){
+	this._predicate_label = lbl;
+    }
+    return this._predicate_label;
+ };
+
+// Add generic bulk annotation operations to: graph, edge, and node.
+each([noctua_graph, noctua_node, noctua_edge], function(constructr){
+    constructr.prototype.annotations = _annotations;
+    constructr.prototype.add_annotation = _add_annotation;
+    constructr.prototype.get_annotations_by_filter = _get_annotations_by_filter;
+    constructr.prototype.get_annotations_by_key = _get_annotations_by_key;
+    constructr.prototype.get_annotation_by_id = _get_annotation_by_id;
+});
+
+// Add generic evidence (referenced individuals) operations to: edge
+// and node.
+each([noctua_node, noctua_edge], function(constructr){
+    constructr.prototype.referenced_subgraphs =
+	_referenced_subgraphs;
+    constructr.prototype.add_referenced_subgraph =
+	_add_referenced_subgraph;
+    constructr.prototype.get_referenced_subgraphs_by_filter =
+	_get_referenced_subgraphs_by_filter;
+    constructr.prototype.get_referenced_subgraph_by_id =
+	_get_referenced_subgraph_by_id;
+    constructr.prototype.get_referenced_subgraph_profiles =
+	_get_referenced_subgraph_profiles;
+    constructr.prototype.get_basic_evidence =
+	_get_basic_evidence;
+});
+
+///
+/// Exportable body.
+///
+
+export default {
+    annotation: annotation,
+    node: noctua_node,
+    edge: noctua_edge,
+    graph: noctua_graph
+};

--- a/packages/bbop-graph-noctua/src/noctua.js
+++ b/packages/bbop-graph-noctua/src/noctua.js
@@ -41,25 +41,25 @@ var keys = us.keys;
 
 // Change these as necessary.
 var debug_map = {
-    // 'gomodel:5798651000000002/5798651000000003': 'set of upper jaw teeth',
-    // 'gomodel:5798651000000002/5798651000000004': 'sharp',
-    // 'gomodel:5798651000000002/5798651000000005': 'mouth',
-    // 'gomodel:5798651000000002/5798651000000006': 'pointed',
-    // 'gomodel:5798651000000002/5798651000000008': 'tongue',
-    // 'gomodel:5798651000000002/5798651000000009': 'lip',
-    // 'gomodel:5798651000000002/5798651000000010': 'tusk',
-    // 'gomodel:5798651000000002/5798651000000033': 'taste bud'
+  // 'gomodel:5798651000000002/5798651000000003': 'set of upper jaw teeth',
+  // 'gomodel:5798651000000002/5798651000000004': 'sharp',
+  // 'gomodel:5798651000000002/5798651000000005': 'mouth',
+  // 'gomodel:5798651000000002/5798651000000006': 'pointed',
+  // 'gomodel:5798651000000002/5798651000000008': 'tongue',
+  // 'gomodel:5798651000000002/5798651000000009': 'lip',
+  // 'gomodel:5798651000000002/5798651000000010': 'tusk',
+  // 'gomodel:5798651000000002/5798651000000033': 'taste bud'
 };
-var dd = function(id){
-    var ret = id;
-    if( debug_map[id] ){
-	ret = debug_map[id];
-    }
-    return ret;
+var dd = function (id) {
+  var ret = id;
+  if (debug_map[id]) {
+    ret = debug_map[id];
+  }
+  return ret;
 };
 
-function log(){
-    console.log.apply(console, arguments);
+function log() {
+  console.log.apply(console, arguments);
 }
 
 ///
@@ -83,26 +83,25 @@ function log(){
  * @param {Object} [kv_set] - optional a set of keys and values; a simple object
  * @returns {this} new instance
  */
-function annotation(kv_set){
-    this._id = bbop.uuid();
+function annotation(kv_set) {
+  this._id = bbop.uuid();
 
-    this._properties = {};
+  this._properties = {};
 
-    if( kv_set && bbop.what_is(kv_set) === 'object' ){
-
-	// Attempt to convert
-	if( kv_set['key'] && kv_set['value'] ){
-	    // var key = kv_set['key'];
-	    // var val = kv_set['value'];
-	    // var adj_set = {};
-	    // adj_set[key] = val;
-	    // Silently pass in value-type if there.
-	    this._properties = bbop.clone(kv_set);
-	}else{
-	    // TODO: Replace this at some point with the logger.
-	    log('bad annotation k/v set: ', kv_set);
-	}
+  if (kv_set && bbop.what_is(kv_set) === "object") {
+    // Attempt to convert
+    if (kv_set["key"] && kv_set["value"]) {
+      // var key = kv_set['key'];
+      // var val = kv_set['value'];
+      // var adj_set = {};
+      // adj_set[key] = val;
+      // Silently pass in value-type if there.
+      this._properties = bbop.clone(kv_set);
+    } else {
+      // TODO: Replace this at some point with the logger.
+      log("bad annotation k/v set: ", kv_set);
     }
+  }
 }
 
 /**
@@ -110,8 +109,8 @@ function annotation(kv_set){
  *
  * @returns {String} string
  */
-annotation.prototype.id = function(){
-    return this._id;
+annotation.prototype.id = function () {
+  return this._id;
 };
 
 /**
@@ -122,28 +121,27 @@ annotation.prototype.id = function(){
  * @param {String} [value_type] - string
  * @returns {String|null} returns property is key
  */
-annotation.prototype.annotation = function(key, value, value_type){
+annotation.prototype.annotation = function (key, value, value_type) {
+  var anchor = this;
+  var ret = null;
 
-    var anchor = this;
-    var ret = null;
+  // Set if the key and value are there.
+  if (key) {
+    if (typeof value !== "undefined") {
+      anchor._properties["key"] = key;
+      anchor._properties["value"] = value;
 
-    // Set if the key and value are there.
-    if( key ){
-	if( typeof(value) !== 'undefined' ){
-	    anchor._properties['key'] = key;
-	    anchor._properties['value'] = value;
-
-	    // Add or get rid of value type depending.
-	    if( typeof(value_type) === 'undefined' ){
-		delete anchor._properties['value-type'];
-	    }else{
-		anchor._properties['value-type'] = value_type;
-	    }
-	}
+      // Add or get rid of value type depending.
+      if (typeof value_type === "undefined") {
+        delete anchor._properties["value-type"];
+      } else {
+        anchor._properties["value-type"] = value_type;
+      }
     }
-    ret = anchor._properties;
+  }
+  ret = anchor._properties;
 
-    return ret;
+  return ret;
 };
 
 /**
@@ -152,10 +150,12 @@ annotation.prototype.annotation = function(key, value, value_type){
  * @param {String} [key] - string
  * @returns {String|null} returns string of annotation
  */
-annotation.prototype.key = function(key){
-    var anchor = this;
-    if( key ){ anchor._properties['key'] = key; }
-    return anchor._properties['key'];
+annotation.prototype.key = function (key) {
+  var anchor = this;
+  if (key) {
+    anchor._properties["key"] = key;
+  }
+  return anchor._properties["key"];
 };
 
 /**
@@ -164,10 +164,12 @@ annotation.prototype.key = function(key){
  * @param {String} [value] - string
  * @returns {String|null} returns string of annotation
  */
-annotation.prototype.value = function(value){
-    var anchor = this;
-    if( value ){ anchor._properties['value'] = value; }
-    return anchor._properties['value'];
+annotation.prototype.value = function (value) {
+  var anchor = this;
+  if (value) {
+    anchor._properties["value"] = value;
+  }
+  return anchor._properties["value"];
 };
 
 /**
@@ -176,10 +178,12 @@ annotation.prototype.value = function(value){
  * @param {String} [value_type] - string
  * @returns {String|null} returns string of annotation
  */
-annotation.prototype.value_type = function(value_type){
-    var anchor = this;
-    if( value_type ){ anchor._properties['value-type'] = value_type; }
-    return anchor._properties['value-type'];
+annotation.prototype.value_type = function (value_type) {
+  var anchor = this;
+  if (value_type) {
+    anchor._properties["value-type"] = value_type;
+  }
+  return anchor._properties["value-type"];
 };
 
 /**
@@ -188,17 +192,16 @@ annotation.prototype.value_type = function(value_type){
  * @param {String} key - string
  * @returns {Boolean} true if not empty
  */
-annotation.prototype.delete = function(){
+annotation.prototype.delete = function () {
+  var anchor = this;
+  var ret = false;
 
-    var anchor = this;
-    var ret = false;
+  if (!us.isEmpty(anchor._properties)) {
+    anchor._properties = {}; // nuke
+    ret = true;
+  }
 
-    if( ! us.isEmpty(anchor._properties) ){
-	anchor._properties = {}; // nuke
-	ret = true;
-    }
-
-    return ret;
+  return ret;
 };
 
 /**
@@ -206,21 +209,27 @@ annotation.prototype.delete = function(){
  *
  * @returns {annotation} a fresh annotation for no shared structure
  */
-annotation.prototype.clone = function(){
-    var anchor = this;
+annotation.prototype.clone = function () {
+  var anchor = this;
 
-    // Copy most of the data structure.
-    var a = {};
-    if( anchor.key() ){ a['key'] = anchor.key(); }
-    if( anchor.value() ){ a['value'] = anchor.value(); }
-    if( anchor.value_type() ){ a['value-type'] = anchor.value_type(); }
+  // Copy most of the data structure.
+  var a = {};
+  if (anchor.key()) {
+    a["key"] = anchor.key();
+  }
+  if (anchor.value()) {
+    a["value"] = anchor.value();
+  }
+  if (anchor.value_type()) {
+    a["value-type"] = anchor.value_type();
+  }
 
-    var new_ann = new annotation(a);
+  var new_ann = new annotation(a);
 
-    // Copy ID as well.
-    new_ann._id = anchor._id;
+  // Copy ID as well.
+  new_ann._id = anchor._id;
 
-    return new_ann;
+  return new_ann;
 };
 
 ///
@@ -241,25 +250,24 @@ annotation.prototype.clone = function(){
  * @param {Object} [vobj] - optional TBD object structure for violations
  * @returns {this} new instance
  */
-function violation(vobj){
+function violation(vobj) {
+  this._id = bbop.uuid();
+  this._node = null;
+  this._explanations = [];
 
-    this._id = bbop.uuid();
-    this._node = null;
-    this._explanations = [];
+  if (us.isString(vobj["node"])) {
+    this._node = bbop.clone(vobj["node"]);
+  } else {
+    log("bad violation node: ", this._id);
+  }
 
-    if( us.isString(vobj['node']) ){
-	this._node = bbop.clone(vobj['node']);
-    }else{
-	log('bad violation node: ', this._id);
-    }
+  if (us.isArray(vobj["explanations"])) {
+    this._explanations = bbop.clone(vobj["explanations"]);
+  } else {
+    log("bad violation explanations: ", this._id);
+  }
 
-    if( us.isArray(vobj['explanations']) ){
-	this._explanations = bbop.clone(vobj['explanations']);
-    }else{
-	log('bad violation explanations: ', this._id);
-    }
-
-    return this;
+  return this;
 }
 
 /**
@@ -267,8 +275,8 @@ function violation(vobj){
  *
  * @returns {String} string
  */
-violation.prototype.id = function(){
-    return this._id;
+violation.prototype.id = function () {
+  return this._id;
 };
 
 /**
@@ -276,8 +284,8 @@ violation.prototype.id = function(){
  *
  * @returns {String} string
  */
-violation.prototype.node_id = function(){
-    return this._node;
+violation.prototype.node_id = function () {
+  return this._node;
 };
 
 /**
@@ -285,8 +293,8 @@ violation.prototype.node_id = function(){
  *
  * @returns {String} string
  */
-violation.prototype.explanations = function(){
-    return this._explanations;
+violation.prototype.explanations = function () {
+  return this._explanations;
 };
 
 /**
@@ -294,16 +302,16 @@ violation.prototype.explanations = function(){
  *
  * @returns {violation} a fresh violation...
  */
-violation.prototype.clone = function(){
-    var anchor = this;
+violation.prototype.clone = function () {
+  var anchor = this;
 
-    var v = {};
-    v['node'] = anchor.node_id();
-    v['explanations'] = anchor.explanations();
+  var v = {};
+  v["node"] = anchor.node_id();
+  v["explanations"] = anchor.explanations();
 
-    // Our constructor will use all new material, so no problem.
-    var new_vio = new violation(v);
-    return new_vio;
+  // Our constructor will use all new material, so no problem.
+  var new_vio = new violation(v);
+  return new_vio;
 };
 
 ///
@@ -319,11 +327,11 @@ violation.prototype.clone = function(){
  * @param {Array} [in_anns] - list of annotations to clobber current list
  * @returns {Array} list of all annotations
  */
-function _annotations(in_anns){
-    if( us.isArray(in_anns) ){
-	this._annotations = in_anns;
-    }
-    return this._annotations;
+function _annotations(in_anns) {
+  if (us.isArray(in_anns)) {
+    this._annotations = in_anns;
+  }
+  return this._annotations;
 }
 
 /**
@@ -334,11 +342,11 @@ function _annotations(in_anns){
  * @param {annotation} in_ann - annotation to add
  * @returns {Array} list of all annotations
  */
-function _add_annotation(in_ann){
-    if( ! us.isArray(in_ann) ){
-	this._annotations.push(in_ann);
-    }
-    return this._annotations;
+function _add_annotation(in_ann) {
+  if (!us.isArray(in_ann)) {
+    this._annotations.push(in_ann);
+  }
+  return this._annotations;
 }
 
 /**
@@ -351,17 +359,16 @@ function _add_annotation(in_ann){
  * @param {Function} filter - function described above
  * @returns {Array} list of passing annotations
  */
-function _get_annotations_by_filter(filter){
-
-    var anchor = this;
-    var ret = [];
-    each(anchor._annotations, function(ann){
-	var res = filter(ann);
-	if( res && res === true ){
-	    ret.push(ann);
-	}
-    });
-    return ret;
+function _get_annotations_by_filter(filter) {
+  var anchor = this;
+  var ret = [];
+  each(anchor._annotations, function (ann) {
+    var res = filter(ann);
+    if (res && res === true) {
+      ret.push(ann);
+    }
+  });
+  return ret;
 }
 
 /**
@@ -372,17 +379,17 @@ function _get_annotations_by_filter(filter){
  * @param {String} key - key to look for.
  * @returns {Array} list of list of annotations with that key
  */
-function _get_annotations_by_key(key){
-    var anchor = this;
+function _get_annotations_by_key(key) {
+  var anchor = this;
 
-    var ret = [];
-    each(anchor._annotations, function(ann){
-	if( ann.key() === key ){
-	    ret.push(ann);
-	}
-    });
+  var ret = [];
+  each(anchor._annotations, function (ann) {
+    if (ann.key() === key) {
+      ret.push(ann);
+    }
+  });
 
-    return ret;
+  return ret;
 }
 
 /**
@@ -393,16 +400,15 @@ function _get_annotations_by_key(key){
  * @param {String} aid - annotation ID to look for
  * @returns {Array} list of list of annotations with that ID
  */
-function _get_annotation_by_id(aid){
-
-    var anchor = this;
-    var ret = null;
-    each(anchor._annotations, function(ann){
-	if( ann.id() === aid ){
-	    ret = ann;
-	}
-    });
-    return ret;
+function _get_annotation_by_id(aid) {
+  var anchor = this;
+  var ret = null;
+  each(anchor._annotations, function (ann) {
+    if (ann.id() === aid) {
+      ret = ann;
+    }
+  });
+  return ret;
 }
 
 ///
@@ -420,20 +426,17 @@ function _get_annotation_by_id(aid){
  * @param {Array} [subgraphs] - list of {graph} to clobber current list
  * @returns {Array} list of all referenced subgraphs
  */
-function _referenced_subgraphs(subgraphs){
-
-    if( us.isArray(subgraphs) ){
-
-	// Not copies, so add by replacement.
-	this._referenced_subgraphs = [];
-	// // Convert type.
-	each(subgraphs, function(g){
-	    //g.type('referenced');
-	    this._referenced_subgraphs.push(g.clone());
-	});
-
-    }
-    return this._referenced_subgraphs;
+function _referenced_subgraphs(subgraphs) {
+  if (us.isArray(subgraphs)) {
+    // Not copies, so add by replacement.
+    this._referenced_subgraphs = [];
+    // // Convert type.
+    each(subgraphs, function (g) {
+      //g.type('referenced');
+      this._referenced_subgraphs.push(g.clone());
+    });
+  }
+  return this._referenced_subgraphs;
 }
 
 /**
@@ -444,12 +447,12 @@ function _referenced_subgraphs(subgraphs){
  * @param {graph} subgraph - subgraph to add
  * @returns {Array} list of all subgraphs
  */
-function _add_referenced_subgraph(subgraph){
-    if( ! us.isArray(subgraph) ){
-	//subgraph.type('referenced');
-	this._referenced_subgraphs.push(subgraph);
-    }
-    return this._referenced_subgraphs;
+function _add_referenced_subgraph(subgraph) {
+  if (!us.isArray(subgraph)) {
+    //subgraph.type('referenced');
+    this._referenced_subgraphs.push(subgraph);
+  }
+  return this._referenced_subgraphs;
 }
 
 /**
@@ -462,39 +465,39 @@ function _add_referenced_subgraph(subgraph){
  * @param {Function} filter - function described above
  * @returns {Array} list of passing subgraphs
  */
-function _get_referenced_subgraphs_by_filter(filter){
-    var anchor = this;
+function _get_referenced_subgraphs_by_filter(filter) {
+  var anchor = this;
 
-    var ret = [];
-    each(anchor._referenced_subgraphs, function(g){
-	var res = filter(g);
-	if( res && res === true ){
-	    ret.push(g);
-	}
-    });
+  var ret = [];
+  each(anchor._referenced_subgraphs, function (g) {
+    var res = filter(g);
+    if (res && res === true) {
+      ret.push(g);
+    }
+  });
 
-    return ret;
+  return ret;
 }
 
 /**
-* Get a referenced_subgraph with a certain ID.
+ * Get a referenced_subgraph with a certain ID.
  *
  * @name get_referenced_subgraph_by_id
  * @function
  * @param {String} iid - referenced_individual ID to look for
  * @returns {Object|null} referenced_subgraph with that ID
  */
-function _get_referenced_subgraph_by_id(iid){
-    var anchor = this;
+function _get_referenced_subgraph_by_id(iid) {
+  var anchor = this;
 
-    var ret = null;
-    each(anchor._referenced_subgraphs, function(g){
-	if( g.id() === iid ){
-	    ret = g;
-	}
-    });
+  var ret = null;
+  each(anchor._referenced_subgraphs, function (g) {
+    if (g.id() === iid) {
+      ret = g;
+    }
+  });
 
-    return ret;
+  return ret;
 }
 
 /**
@@ -519,58 +522,58 @@ function _get_referenced_subgraph_by_id(iid){
  * @param {Function} [extractor] extraction functions to use instead of default
  * @returns {Array} list of referenced_individual information
  */
-function _get_referenced_subgraph_profiles(extractor){
-    var anchor = this;
+function _get_referenced_subgraph_profiles(extractor) {
+  var anchor = this;
 
-    //
-    function extractor_default(g){
-	var ret = null;
+  //
+  function extractor_default(g) {
+    var ret = null;
 
-	// If singleton.
-	if( g.all_nodes().length === 1 ){
-	    var ind = g.all_nodes()[0];
+    // If singleton.
+    if (g.all_nodes().length === 1) {
+      var ind = g.all_nodes()[0];
 
-	    // Base.
-	    var prof = {
-		id: null,
-		class_expressions: [],
-		annotations: []
-	    };
+      // Base.
+      var prof = {
+        id: null,
+        class_expressions: [],
+        annotations: [],
+      };
 
-	    // Referenced instance ID.
-	    prof['id'] = ind.id();
+      // Referenced instance ID.
+      prof["id"] = ind.id();
 
-	    // Collect class expressions and annotations.
-	    each(ind.types(), function(ce){
-		prof['class_expressions'].push(ce);
-	    });
-	    each(ind.annotations(), function(ann){
-		prof['annotations'].push(ann);
-	    });
+      // Collect class expressions and annotations.
+      each(ind.types(), function (ce) {
+        prof["class_expressions"].push(ce);
+      });
+      each(ind.annotations(), function (ann) {
+        prof["annotations"].push(ann);
+      });
 
-	    //
-	    ret = prof;
-	}
-
-	return ret;
+      //
+      ret = prof;
     }
-
-    // If we are using the simple standard.
-    if( typeof(extractor) !== 'function' ){
-	extractor = extractor_default;
-    }
-
-    // Run the extractor over the referenced subraph in the calling
-    // node.
-    var ret = [];
-    each(anchor.referenced_subgraphs(), function(g){
-	var extracted = extractor(g);
-	if( extracted ){
-	    ret.push(extracted);
-	}
-    });
 
     return ret;
+  }
+
+  // If we are using the simple standard.
+  if (typeof extractor !== "function") {
+    extractor = extractor_default;
+  }
+
+  // Run the extractor over the referenced subraph in the calling
+  // node.
+  var ret = [];
+  each(anchor.referenced_subgraphs(), function (g) {
+    var extracted = extractor(g);
+    if (extracted) {
+      ret.push(extracted);
+    }
+  });
+
+  return ret;
 }
 
 /**
@@ -596,43 +599,44 @@ function _get_referenced_subgraph_profiles(extractor){
  * @param {Array} annotation_ids - list of strings that identify the annotation keys that will be captured--
  * @returns {Array} list of referenced_individual simple evidence information.
  */
-function _get_basic_evidence(annotation_ids){
-    var anchor = this;
+function _get_basic_evidence(annotation_ids) {
+  var anchor = this;
 
-    var ret = [];
+  var ret = [];
 
-    // Get hash of the annotation keys present.
-    var test = us.object(us.map(annotation_ids,
-				function(e){ return [e, true]; }));
+  // Get hash of the annotation keys present.
+  var test = us.object(
+    us.map(annotation_ids, function (e) {
+      return [e, true];
+    }),
+  );
 
-    each(anchor.get_referenced_subgraph_profiles(), function(cmplx_prof){
-	//console.log(cmplx_prof);
+  each(anchor.get_referenced_subgraph_profiles(), function (cmplx_prof) {
+    //console.log(cmplx_prof);
 
-	// Only add conformant referenced individuals.
-	if( cmplx_prof.id && ! us.isEmpty(cmplx_prof.class_expressions) ){
+    // Only add conformant referenced individuals.
+    if (cmplx_prof.id && !us.isEmpty(cmplx_prof.class_expressions)) {
+      // Base.
+      //console.log(cmplx_prof.class_expressions);
+      var basic_prof = {
+        id: cmplx_prof.id,
+        cls: cmplx_prof.class_expressions[0].to_string(),
+      };
 
-	    // Base.
-	    //console.log(cmplx_prof.class_expressions);
-	    var basic_prof = {
-		id: cmplx_prof.id,
-		cls: cmplx_prof.class_expressions[0].to_string()
-	    };
+      // Match and clobber.
+      each(cmplx_prof.annotations, function (ann) {
+        //console.log(ann);
+        if (test[ann.key()]) {
+          basic_prof[ann.key()] = ann.value();
+        }
+      });
 
-	    // Match and clobber.
-	    each(cmplx_prof.annotations, function(ann){
-		//console.log(ann);
-		if( test[ann.key()] ){
-		    basic_prof[ann.key()] = ann.value();
-		}
-	    });
+      //console.log(basic_prof);
+      ret.push(basic_prof);
+    }
+  });
 
-	    //console.log(basic_prof);
-	    ret.push(basic_prof);
-	}
-
-    });
-
-    return ret;
+  return ret;
 }
 
 ///
@@ -654,41 +658,41 @@ var bbop_graph = bbop_model.graph;
  * @param {String} [new_id] - new id; otherwise new unique generated
  * @returns {this}
  */
-function noctua_graph(new_id){
-    bbop_graph.call(this);
-    this._is_a = 'bbop-graph-noctua.graph';
+function noctua_graph(new_id) {
+  bbop_graph.call(this);
+  this._is_a = "bbop-graph-noctua.graph";
 
-    // Deal with id or generate a new one.
-    if( typeof(new_id) !== 'undefined' ){
-	this.id(new_id);
-    }
+  // Deal with id or generate a new one.
+  if (typeof new_id !== "undefined") {
+    this.id(new_id);
+  }
 
-    // The old edit core.
-    this.core = {
-	'edges': {}, // map of id to edit_edge - edges not completely anonymous
-	'node_order': [], // initial table order on redraws
-	'node2elt': {}, // map of id to physical object id
-	'elt2node': {},  // map of physical object id to id
-	// Remeber that edge ids and elts ids are the same, so no map
-	// is needed.
-	'edge2connector': {}, // map of edge id to virtual connector id
-	'connector2edge': {}  // map of virtual connector id to edge id
-    };
+  // The old edit core.
+  this.core = {
+    edges: {}, // map of id to edit_edge - edges not completely anonymous
+    node_order: [], // initial table order on redraws
+    node2elt: {}, // map of id to physical object id
+    elt2node: {}, // map of physical object id to id
+    // Remeber that edge ids and elts ids are the same, so no map
+    // is needed.
+    edge2connector: {}, // map of edge id to virtual connector id
+    connector2edge: {}, // map of virtual connector id to edge id
+  };
 
-    this._annotations = [];
-    //this._referenced_subgraphs = []; // not for graph yet, or maybe ever
+  this._annotations = [];
+  //this._referenced_subgraphs = []; // not for graph yet, or maybe ever
 
-    // Some things that come up in live noctua environments. These are
-    // graph properties that may or may not be there. If unknown,
-    // null; if positively true (bad), true; may be false otherwise.
-    this._inconsistent_p = null;
-    this._modified_p = null;
+  // Some things that come up in live noctua environments. These are
+  // graph properties that may or may not be there. If unknown,
+  // null; if positively true (bad), true; may be false otherwise.
+  this._inconsistent_p = null;
+  this._modified_p = null;
 
-    // New section as we work out how violations operate.
-    this._violations = [];
-    this._valid_p = true;
-    this._valid_owl_p = true;
-    this._valid_shex_p = true;
+  // New section as we work out how violations operate.
+  this._violations = [];
+  this._valid_p = true;
+  this._valid_owl_p = true;
+  this._valid_shex_p = true;
 }
 bbop.extend(noctua_graph, bbop_graph);
 
@@ -700,8 +704,8 @@ bbop.extend(noctua_graph, bbop_graph);
  * @param {string} [predicate] - a user-friendly description of the node
  * @returns {edge} bbop model edge
  */
-noctua_graph.prototype.create_edge = function(subject, object, predicate){
-    return new noctua_edge(subject, object, predicate);
+noctua_graph.prototype.create_edge = function (subject, object, predicate) {
+  return new noctua_edge(subject, object, predicate);
 };
 
 /**
@@ -713,8 +717,15 @@ noctua_graph.prototype.create_edge = function(subject, object, predicate){
  * @param {Array} [inferred_types] - list of inferred types to pre-load
  * @returns {node} new bbop model node
  */
-noctua_graph.prototype.create_node = function(id, label, types, root_types, inferred_types, inferred_types_with_all){
-    return new noctua_node(id, label, types, root_types, inferred_types, inferred_types_with_all);
+noctua_graph.prototype.create_node = function (
+  id,
+  label,
+  types,
+  root_types,
+  inferred_types,
+  inferred_types_with_all,
+) {
+  return new noctua_node(id, label, types, root_types, inferred_types, inferred_types_with_all);
 };
 
 /**
@@ -724,41 +735,41 @@ noctua_graph.prototype.create_node = function(id, label, types, root_types, infe
  *
  * @returns {graph} bbop model graph
  */
-noctua_graph.prototype.clone = function(){
-    var anchor = this;
+noctua_graph.prototype.clone = function () {
+  var anchor = this;
 
-    var new_graph = anchor.create_graph();
+  var new_graph = anchor.create_graph();
 
-    // Collect the nodes and edges.
-    each(anchor.all_nodes(), function(node){
-	new_graph.add_node(node.clone());
-    });
-    each(anchor.all_edges(), function(edge){
-	new_graph.add_edge(edge.clone());
-    });
+  // Collect the nodes and edges.
+  each(anchor.all_nodes(), function (node) {
+    new_graph.add_node(node.clone());
+  });
+  each(anchor.all_edges(), function (edge) {
+    new_graph.add_edge(edge.clone());
+  });
 
-    // Collect other information.
-    new_graph.default_predicate = anchor.default_predicate;
-    new_graph._id = anchor._id;
+  // Collect other information.
+  new_graph.default_predicate = anchor.default_predicate;
+  new_graph._id = anchor._id;
 
-    // Copy new things: annotations.
-    each(anchor._annotations, function(annotation){
-	new_graph._annotations.push(annotation.clone());
-    });
+  // Copy new things: annotations.
+  each(anchor._annotations, function (annotation) {
+    new_graph._annotations.push(annotation.clone());
+  });
 
-    // Copy other properties over.
-    new_graph._inconsistent_p = anchor._inconsistent_p;
-    new_graph._modified_p = anchor._modified_p;
+  // Copy other properties over.
+  new_graph._inconsistent_p = anchor._inconsistent_p;
+  new_graph._modified_p = anchor._modified_p;
 
-    // Copy violation information over.
-    each(anchor._violations, function(v){
-	new_graph._violations.push(v.clone());
-    });
-    new_graph._valid_p = anchor._valid_p;
-    new_graph._valid_owl_p = anchor._valid_owl_p;
-    new_graph._valid_shex_p = anchor._valid_shex_p;
+  // Copy violation information over.
+  each(anchor._violations, function (v) {
+    new_graph._violations.push(v.clone());
+  });
+  new_graph._valid_p = anchor._valid_p;
+  new_graph._valid_owl_p = anchor._valid_owl_p;
+  new_graph._valid_shex_p = anchor._valid_shex_p;
 
-    return new_graph;
+  return new_graph;
 };
 
 /**
@@ -766,8 +777,8 @@ noctua_graph.prototype.clone = function(){
  *
  * @returns {graph} bbop model graph
  */
-noctua_graph.prototype.create_graph = function(){
-    return new noctua_graph();
+noctua_graph.prototype.create_graph = function () {
+  return new noctua_graph();
 };
 
 /**
@@ -780,8 +791,8 @@ noctua_graph.prototype.create_graph = function(){
  * @param {String} id - string
  * @returns {String} string
  */
-noctua_graph.prototype.add_id = function(id){
-    return this.id(id);
+noctua_graph.prototype.add_id = function (id) {
+  return this.id(id);
 };
 
 /**
@@ -793,8 +804,8 @@ noctua_graph.prototype.add_id = function(id){
  * @see module:bbop-graph#id
  * @returns {String} string
  */
-noctua_graph.prototype.get_id = function(){
-    return this.id();
+noctua_graph.prototype.get_id = function () {
+  return this.id();
 };
 
 /**
@@ -803,8 +814,8 @@ noctua_graph.prototype.get_id = function(){
  *
  * @returns {Boolean|null} inconsistent or not; null if unknown
  */
-noctua_graph.prototype.inconsistent_p = function(){
-    return this._inconsistent_p;
+noctua_graph.prototype.inconsistent_p = function () {
+  return this._inconsistent_p;
 };
 
 /**
@@ -813,8 +824,8 @@ noctua_graph.prototype.inconsistent_p = function(){
  *
  * @returns {Boolean|null} inconsistent or not; null if unknown
  */
-noctua_graph.prototype.modified_p = function(){
-    return this._modified_p;
+noctua_graph.prototype.modified_p = function () {
+  return this._modified_p;
 };
 
 /**
@@ -824,8 +835,8 @@ noctua_graph.prototype.modified_p = function(){
  *
  * @returns {Boolean} p - bool
  */
-noctua_graph.prototype.valid_p = function(){
-    return this._valid_p;
+noctua_graph.prototype.valid_p = function () {
+  return this._valid_p;
 };
 
 /**
@@ -835,8 +846,8 @@ noctua_graph.prototype.valid_p = function(){
  *
  * @returns {Boolean} p - bool
  */
-noctua_graph.prototype.valid_owl_p = function(){
-    return this._valid_owl_p;
+noctua_graph.prototype.valid_owl_p = function () {
+  return this._valid_owl_p;
 };
 
 /**
@@ -846,8 +857,8 @@ noctua_graph.prototype.valid_owl_p = function(){
  *
  * @returns {Boolean} p - bool
  */
-noctua_graph.prototype.valid_shex_p = function(){
-    return this._valid_shex_p;
+noctua_graph.prototype.valid_shex_p = function () {
+  return this._valid_shex_p;
 };
 
 /**
@@ -856,8 +867,8 @@ noctua_graph.prototype.valid_shex_p = function(){
  *
  * @returns {Array} violations or an empty list if none
  */
-noctua_graph.prototype.violations = function(){
-    return this._violations;
+noctua_graph.prototype.violations = function () {
+  return this._violations;
 };
 
 /**
@@ -866,18 +877,18 @@ noctua_graph.prototype.violations = function(){
  * @param {String} node_id - the ID of the {edge}
  * @returns {Array|Null} - Returns a list of 'violation' found in the graph for a given id.
  */
-noctua_graph.prototype.get_violations_by_id = function(node_id){
-    var ret = [];
+noctua_graph.prototype.get_violations_by_id = function (node_id) {
+  var ret = [];
 
-    // TODO: needs to be optimized once we figure out how we handle
-    // shex + owl + whatever as general objects in here.
-    each(this.violations(), function(v){
-	if( v.node_id() === node_id ){
-	    ret.push(v.clone());
-	}
-    });
+  // TODO: needs to be optimized once we figure out how we handle
+  // shex + owl + whatever as general objects in here.
+  each(this.violations(), function (v) {
+    if (v.node_id() === node_id) {
+      ret.push(v.clone());
+    }
+  });
 
-    return ret;
+  return ret;
 };
 
 /**
@@ -886,28 +897,29 @@ noctua_graph.prototype.get_violations_by_id = function(node_id){
  * @param {node} enode - noctua node
  * @returns {Boolean} true on new node
  */
-noctua_graph.prototype.add_node = function(enode){
-    // Super call: add it to the general graph.
-    bbop_graph.prototype.add_node.call(this, enode);
+noctua_graph.prototype.add_node = function (enode) {
+  // Super call: add it to the general graph.
+  bbop_graph.prototype.add_node.call(this, enode);
 
-    var ret = false;
+  var ret = false;
 
-    // Add/update node.
-    var enid = enode.id();
-    //this.core['nodes'][enid] = enode; // add to nodes
+  // Add/update node.
+  var enid = enode.id();
+  //this.core['nodes'][enid] = enode; // add to nodes
 
-    // Only create a new elt ID and order if one isn't already in
-    // there (or reuse things to keep GUI working smoothly).
-    var elt_id = this.core['node2elt'][enid];
-    if( ! elt_id ){ // first time
-	this.core['node_order'].unshift(enid); // add to default order
-	elt_id = bbop.uuid(); // generate the elt id we'll use from now on
-	this.core['node2elt'][enid] = elt_id; // map it
-	this.core['elt2node'][elt_id] = enid; // map it
-	ret = true;
-    }
+  // Only create a new elt ID and order if one isn't already in
+  // there (or reuse things to keep GUI working smoothly).
+  var elt_id = this.core["node2elt"][enid];
+  if (!elt_id) {
+    // first time
+    this.core["node_order"].unshift(enid); // add to default order
+    elt_id = bbop.uuid(); // generate the elt id we'll use from now on
+    this.core["node2elt"][enid] = elt_id; // map it
+    this.core["elt2node"][elt_id] = enid; // map it
+    ret = true;
+  }
 
-    return ret;
+  return ret;
 };
 
 /**
@@ -917,42 +929,40 @@ noctua_graph.prototype.add_node = function(enode){
  * @param {Object} indv - hash rep of graph individual from Minerva response?
  * @returns {node|null}
  */
-noctua_graph.prototype.add_node_from_individual = function(indv){
-    var anchor = this;
+noctua_graph.prototype.add_node_from_individual = function (indv) {
+  var anchor = this;
 
-    var new_node = null;
+  var new_node = null;
 
-    // Add individual to edit core if properly structured.
-    var iid = indv['id'];
-    if( iid ){
-	//var nn = new bbop.model.node(indv['id']);
-	//var meta = {};
-	//ll('indv');
+  // Add individual to edit core if properly structured.
+  var iid = indv["id"];
+  if (iid) {
+    //var nn = new bbop.model.node(indv['id']);
+    //var meta = {};
+    //ll('indv');
 
-	// See if there is type info that we want to add.
-	// Create the node.
-	var itypes = indv['type'] || [];
-	var root_itypes = indv['root-type'] || [];
-	var inf_itypes = indv['inferred-type'] || [];
-	var inf_itypes_with_all = indv['inferred-type-with-all'] || [];
-	new_node = anchor.create_node(iid, null, itypes,
-                                      root_itypes, inf_itypes,
-                                      inf_itypes_with_all);
+    // See if there is type info that we want to add.
+    // Create the node.
+    var itypes = indv["type"] || [];
+    var root_itypes = indv["root-type"] || [];
+    var inf_itypes = indv["inferred-type"] || [];
+    var inf_itypes_with_all = indv["inferred-type-with-all"] || [];
+    new_node = anchor.create_node(iid, null, itypes, root_itypes, inf_itypes, inf_itypes_with_all);
 
-	// See if there is type info that we want to add.
-	var ianns = indv['annotations'] || [];
-	if( us.isArray(ianns) ){
-	    // Add the annotations individually.
-	    each(ianns, function(ann_kv_set){
-		var na = new annotation(ann_kv_set);
-		new_node.add_annotation(na);
-	    });
-	}
-
-	anchor.add_node(new_node);
+    // See if there is type info that we want to add.
+    var ianns = indv["annotations"] || [];
+    if (us.isArray(ianns)) {
+      // Add the annotations individually.
+      each(ianns, function (ann_kv_set) {
+        var na = new annotation(ann_kv_set);
+        new_node.add_annotation(na);
+      });
     }
 
-    return new_node;
+    anchor.add_node(new_node);
+  }
+
+  return new_node;
 };
 
 /**
@@ -960,8 +970,8 @@ noctua_graph.prototype.add_node_from_individual = function(indv){
  *
  * @returns {Array} node order by id?
  */
-noctua_graph.prototype.edit_node_order = function(){
-    return this.core['node_order'] || [];
+noctua_graph.prototype.edit_node_order = function () {
+  return this.core["node_order"] || [];
 };
 
 /**
@@ -969,8 +979,8 @@ noctua_graph.prototype.edit_node_order = function(){
  *
  * @returns {String|null} node element id
  */
-noctua_graph.prototype.get_node_elt_id = function(enid){
-    return this.core['node2elt'][enid] || null;
+noctua_graph.prototype.get_node_elt_id = function (enid) {
+  return this.core["node2elt"][enid] || null;
 };
 
 /**
@@ -978,13 +988,13 @@ noctua_graph.prototype.get_node_elt_id = function(enid){
  *
  * @returns {node|null} node
  */
-noctua_graph.prototype.get_node_by_elt_id = function(elt_id){
-    var ret = null;
-    var enid = this.core['elt2node'][elt_id] || null;
-    if( enid ){
-	ret = this.get_node(enid) || null;
-    }
-    return ret;
+noctua_graph.prototype.get_node_by_elt_id = function (elt_id) {
+  var ret = null;
+  var enid = this.core["elt2node"][elt_id] || null;
+  if (enid) {
+    ret = this.get_node(enid) || null;
+  }
+  return ret;
 };
 
 /**
@@ -993,18 +1003,18 @@ noctua_graph.prototype.get_node_by_elt_id = function(elt_id){
  *
  * @returns {node|null} node
  */
-noctua_graph.prototype.get_node_by_individual = function(indv){
-    var anchor = this;
+noctua_graph.prototype.get_node_by_individual = function (indv) {
+  var anchor = this;
 
-    var ret = null;
+  var ret = null;
 
-    // Get node from graph if individual rep is properly structured.
-    var iid = indv['id'];
-    if( iid ){
-	ret = this.get_node(iid) || null;
-    }
+  // Get node from graph if individual rep is properly structured.
+  var iid = indv["id"];
+  if (iid) {
+    ret = this.get_node(iid) || null;
+  }
 
-    return ret;
+  return ret;
 };
 
 /**
@@ -1014,8 +1024,8 @@ noctua_graph.prototype.get_node_by_individual = function(indv){
  * @see module:bbop-graph#all_nodes
  * @returns {Object} node ids to nodes
  */
-noctua_graph.prototype.get_nodes = function(){
-    return this._nodes || {};
+noctua_graph.prototype.get_nodes = function () {
+  return this._nodes || {};
 };
 
 /**
@@ -1025,39 +1035,39 @@ noctua_graph.prototype.get_nodes = function(){
  * @param {Boolean} [clean_p] - remove all edges connects to node (default false)
  * @returns {Boolean} true if node found and destroyed
  */
-noctua_graph.prototype.remove_node = function(node_id, clean_p){
-    var anchor = this;
+noctua_graph.prototype.remove_node = function (node_id, clean_p) {
+  var anchor = this;
 
-    var ret = false;
-    var enode = anchor.get_node(node_id);
-    if( enode ){
-	ret = true;
+  var ret = false;
+  var enode = anchor.get_node(node_id);
+  if (enode) {
+    ret = true;
 
-	///
-	/// First, remove all subclass decorations.
-	///
+    ///
+    /// First, remove all subclass decorations.
+    ///
 
-	// Also remove the node from the order list.
-	// TODO: Is this a dumb scan?
-	var ni = this.core['node_order'].indexOf(node_id);
-	if( ni !== -1 ){
-	    this.core['node_order'].splice(ni, 1);
-	}
-
-	// Clean the maps.
-	var elt_id = this.core['node2elt'][node_id];
-	delete this.core['node2elt'][node_id];
-	delete this.core['elt2node'][elt_id];
-
-	///
-	/// We want to maintain superclass compatibility.
-	///
-
-	// Finally, remove the node itself.
-	bbop_graph.prototype.remove_node.call(this, node_id, clean_p);
+    // Also remove the node from the order list.
+    // TODO: Is this a dumb scan?
+    var ni = this.core["node_order"].indexOf(node_id);
+    if (ni !== -1) {
+      this.core["node_order"].splice(ni, 1);
     }
 
-    return ret;
+    // Clean the maps.
+    var elt_id = this.core["node2elt"][node_id];
+    delete this.core["node2elt"][node_id];
+    delete this.core["elt2node"][elt_id];
+
+    ///
+    /// We want to maintain superclass compatibility.
+    ///
+
+    // Finally, remove the node itself.
+    bbop_graph.prototype.remove_node.call(this, node_id, clean_p);
+  }
+
+  return ret;
 };
 
 /**
@@ -1066,15 +1076,16 @@ noctua_graph.prototype.remove_node = function(node_id, clean_p){
  *
  * @param {edge} eedge - a bbop-graph-noctua#edge
  */
-noctua_graph.prototype.add_edge = function(eedge){
+noctua_graph.prototype.add_edge = function (eedge) {
+  // Super.
+  bbop_graph.prototype.add_edge.call(this, eedge);
 
-    // Super.
-    bbop_graph.prototype.add_edge.call(this, eedge);
-
-    // Sub.
-   var eeid = eedge.id();
-   if( ! eeid ){ throw new Error('edge not of bbop-graph-noctua'); }
-   this.core['edges'][eeid] = eedge;
+  // Sub.
+  var eeid = eedge.id();
+  if (!eeid) {
+    throw new Error("edge not of bbop-graph-noctua");
+  }
+  this.core["edges"][eeid] = eedge;
 };
 
 /**
@@ -1084,39 +1095,38 @@ noctua_graph.prototype.add_edge = function(eedge){
  * @param {} fact - JSON structure representing a fact
  * @returns {edge} newly created edge
  */
-noctua_graph.prototype.add_edge_from_fact = function(fact){
-    var anchor = this;
+noctua_graph.prototype.add_edge_from_fact = function (fact) {
+  var anchor = this;
 
-    var new_edge = null;
+  var new_edge = null;
 
-    // Add individual to edit core if properly structured.
-    var sid = fact['subject'];
-    var oid = fact['object'];
-    var pid = fact['property'];
-    var plbl = fact['property-label'];
-    var anns = fact['annotations'] || [];
-    if( sid && oid && pid ){
-
-	new_edge = anchor.create_edge(sid, oid, pid);
-	if( ! us.isArray(anns) ){
-	    throw new Error('annotations is wrong');
-	}else{
-	    // Add the annotations individually.
-	    each(anns, function(ann_kv_set){
-		var na = new annotation(ann_kv_set);
-		new_edge.add_annotation(na);
-	    });
-	}
-	// Add edge if possible.
-	if( plbl ){
-	    new_edge.label(plbl);
-	}
-
-	// Add and ready to return edge.
-	anchor.add_edge(new_edge);
+  // Add individual to edit core if properly structured.
+  var sid = fact["subject"];
+  var oid = fact["object"];
+  var pid = fact["property"];
+  var plbl = fact["property-label"];
+  var anns = fact["annotations"] || [];
+  if (sid && oid && pid) {
+    new_edge = anchor.create_edge(sid, oid, pid);
+    if (!us.isArray(anns)) {
+      throw new Error("annotations is wrong");
+    } else {
+      // Add the annotations individually.
+      each(anns, function (ann_kv_set) {
+        var na = new annotation(ann_kv_set);
+        new_edge.add_annotation(na);
+      });
+    }
+    // Add edge if possible.
+    if (plbl) {
+      new_edge.label(plbl);
     }
 
-    return new_edge;
+    // Add and ready to return edge.
+    anchor.add_edge(new_edge);
+  }
+
+  return new_edge;
 };
 
 /**
@@ -1125,11 +1135,13 @@ noctua_graph.prototype.add_edge_from_fact = function(fact){
  * @param {String} edge_id - the ID of the {edge}
  * @returns {edge|null} - the {edge}
  */
-noctua_graph.prototype.get_edge_by_id = function(edge_id){
-    var ret = null;
-    var ep = this.core['edges'][edge_id];
-    if( ep ){ ret = ep; }
-    return ret;
+noctua_graph.prototype.get_edge_by_id = function (edge_id) {
+  var ret = null;
+  var ep = this.core["edges"][edge_id];
+  if (ep) {
+    ret = ep;
+  }
+  return ret;
 };
 
 /**
@@ -1138,8 +1150,8 @@ noctua_graph.prototype.get_edge_by_id = function(edge_id){
  * @param {String} cid - the ID of the connector.
  * @returns {String} - the ID of the associated edge
  */
-noctua_graph.prototype.get_edge_id_by_connector_id = function(cid){
-    return this.core['connector2edge'][cid] || null;
+noctua_graph.prototype.get_edge_id_by_connector_id = function (cid) {
+  return this.core["connector2edge"][cid] || null;
 };
 
 /**
@@ -1148,8 +1160,8 @@ noctua_graph.prototype.get_edge_id_by_connector_id = function(cid){
  * @param {String} eid - the ID of the edge
  * @returns {String} - the connector ID
  */
-noctua_graph.prototype.get_connector_id_by_edge_id = function(eid){
-    return this.core['edge2connector'][eid] || null;
+noctua_graph.prototype.get_connector_id_by_edge_id = function (eid) {
+  return this.core["edge2connector"][eid] || null;
 };
 
 /**
@@ -1179,30 +1191,31 @@ noctua_graph.prototype.get_connector_id_by_edge_id = function(eid){
  * @param {String} edge_id - edge by ID
  * @returns {Boolean} true if such an edge was found and deleted, false otherwise
  */
-noctua_graph.prototype.remove_edge_by_id = function(eeid){
-    var ret = false;
+noctua_graph.prototype.remove_edge_by_id = function (eeid) {
+  var ret = false;
 
-    if( this.core['edges'][eeid] ){
+  if (this.core["edges"][eeid]) {
+    // Summon up the edge to properly remove it from the model.
+    var eedge = this.core["edges"][eeid];
 
-	// Summon up the edge to properly remove it from the model.
-	var eedge = this.core['edges'][eeid];
+    // Remove the node itself from super.
+    ret = bbop_graph.prototype.remove_edge.call(
+      this,
+      eedge.subject_id(),
+      eedge.object_id(),
+      eedge.predicate_id(),
+    );
 
-	// Remove the node itself from super.
-	ret = bbop_graph.prototype.remove_edge.call(this,
-						    eedge.subject_id(),
-						    eedge.object_id(),
-						    eedge.predicate_id());
+    // Main bit out.
+    delete this.core["edges"][eeid];
 
-	// Main bit out.
-	delete this.core['edges'][eeid];
+    // And clean the maps.
+    var cid = this.core["edge2connector"][eeid];
+    delete this.core["edge2connector"][eeid];
+    delete this.core["connector2edge"][cid];
+  }
 
-	// And clean the maps.
-	var cid = this.core['edge2connector'][eeid];
-	delete this.core['edge2connector'][eeid];
-	delete this.core['connector2edge'][cid];
-    }
-
-    return ret;
+  return ret;
 };
 
 /**
@@ -1215,11 +1228,11 @@ noctua_graph.prototype.remove_edge_by_id = function(eeid){
  * @param {edge} eedge - edge
  * @param {connector} connector - jsPlumb connector
  */
-noctua_graph.prototype.create_edge_mapping = function(eedge, connector){
-    var eid = eedge.id();
-    var cid = connector.id;
-    this.core['edge2connector'][eid] = cid;
-    this.core['connector2edge'][cid] = eid;
+noctua_graph.prototype.create_edge_mapping = function (eedge, connector) {
+  var eid = eedge.id();
+  var cid = connector.id;
+  this.core["edge2connector"][eid] = cid;
+  this.core["connector2edge"][cid] = eid;
 };
 
 /**
@@ -1230,26 +1243,25 @@ noctua_graph.prototype.create_edge_mapping = function(eedge, connector){
  * @deprecated
  * @returns {String} a graph rep as a string
  */
-noctua_graph.prototype.dump = function(){
+noctua_graph.prototype.dump = function () {
+  //
+  var dcache = [];
 
-    //
-    var dcache = [];
+  each(this.get_nodes(), function (node, node_id) {
+    var ncache = ["node"];
+    ncache.push(node.id());
+    dcache.push(ncache.join("\t"));
+  });
 
-    each(this.get_nodes(), function(node, node_id){
-	var ncache = ['node'];
-	ncache.push(node.id());
-	dcache.push(ncache.join("\t"));
-    });
+  each(this.core["edges"], function (edge, edge_id) {
+    var ecache = ["edge"];
+    ecache.push(edge.subject_id());
+    ecache.push(edge.predicate_id());
+    ecache.push(edge.object_id());
+    dcache.push(ecache.join("\t"));
+  });
 
-    each(this.core['edges'], function(edge, edge_id){
-	var ecache = ['edge'];
-	ecache.push(edge.subject_id());
-	ecache.push(edge.predicate_id());
-	ecache.push(edge.object_id());
-	dcache.push(ecache.join("\t"));
-    });
-
-    return dcache.join("\n");
+  return dcache.join("\n");
 };
 
 /**
@@ -1265,51 +1277,53 @@ noctua_graph.prototype.dump = function(){
  * @param {graph} in_graph - the graph to merge in
  * @returns {Boolean} if graph was loaded
  */
-noctua_graph.prototype.merge_in = function(in_graph){
-    var anchor = this;
+noctua_graph.prototype.merge_in = function (in_graph) {
+  var anchor = this;
 
-    var ret = bbop_graph.prototype.merge_in.call(anchor, in_graph);
+  var ret = bbop_graph.prototype.merge_in.call(anchor, in_graph);
 
-    // Function to check if two annotations are the same.
-    function _is_same_ann(a1, a2){
-    	var ret = false;
-    	if( a1.key() === a2.key() &&
-    	    a1.value() === a2.value() &&
-    	    a1.value_type() === a2.value_type() ){
-    	    ret = true;
-    	}
-    	return ret;
+  // Function to check if two annotations are the same.
+  function _is_same_ann(a1, a2) {
+    var ret = false;
+    if (a1.key() === a2.key() && a1.value() === a2.value() && a1.value_type() === a2.value_type()) {
+      ret = true;
     }
-
-    // Merge in graph annotations.
-    var in_graph_anns = in_graph.annotations();
-    each(in_graph_anns, function(ann){
-    	// If there are no annotations that have the same KVT triple,
-    	// add a clone.
-    	if( anchor.get_annotations_by_filter( function(a){ return _is_same_ann(ann, a); } ).length === 0 ){
-    	    anchor.add_annotation(ann.clone());
-    	}
-    });
-
-    // Accept the signal that the merge in graph (update) has the
-    // correct modification and inconsistent information.
-    anchor._inconsistent_p = in_graph._inconsistent_p;
-    anchor._modified_p = in_graph._modified_p;
-
-    // Accept the signal that the merge in graph (update) has the
-    // correct validation/violation information.
-    // TODO: Ask @goodb what the semantics are for different
-    // signals when the reasoner are on--I'm assuming we clobber
-    // here.
-    anchor._violations = [];
-    each(in_graph._violations, function(violation){
-	anchor._violations.push(violation.clone());
-    });
-    anchor._valid_p = in_graph._valid_p;
-    anchor._valid_owl_p = in_graph._valid_owl_p;
-    anchor._valid_shex_p = in_graph._valid_shex_p;
-
     return ret;
+  }
+
+  // Merge in graph annotations.
+  var in_graph_anns = in_graph.annotations();
+  each(in_graph_anns, function (ann) {
+    // If there are no annotations that have the same KVT triple,
+    // add a clone.
+    if (
+      anchor.get_annotations_by_filter(function (a) {
+        return _is_same_ann(ann, a);
+      }).length === 0
+    ) {
+      anchor.add_annotation(ann.clone());
+    }
+  });
+
+  // Accept the signal that the merge in graph (update) has the
+  // correct modification and inconsistent information.
+  anchor._inconsistent_p = in_graph._inconsistent_p;
+  anchor._modified_p = in_graph._modified_p;
+
+  // Accept the signal that the merge in graph (update) has the
+  // correct validation/violation information.
+  // TODO: Ask @goodb what the semantics are for different
+  // signals when the reasoner are on--I'm assuming we clobber
+  // here.
+  anchor._violations = [];
+  each(in_graph._violations, function (violation) {
+    anchor._violations.push(violation.clone());
+  });
+  anchor._valid_p = in_graph._valid_p;
+  anchor._valid_owl_p = in_graph._valid_owl_p;
+  anchor._valid_shex_p = in_graph._valid_shex_p;
+
+  return ret;
 };
 
 /**
@@ -1333,32 +1347,32 @@ noctua_graph.prototype.merge_in = function(in_graph){
  * @param {graph} in_graph - the graph to merge in
  * @returns {Boolean} if graph was loaded
  */
-noctua_graph.prototype.merge_special = function(in_graph){
-    var anchor = this;
+noctua_graph.prototype.merge_special = function (in_graph) {
+  var anchor = this;
 
-    // Since we can actually legally have an edge delete in the
-    // merge, let's go ahead and cycle through the "complete"
-    // graph and toss edges from individuals involved in the
-    // merge.
-    var involved_node = {};
-    each(in_graph.all_nodes(), function(node){
-	involved_node[node.id()] = true;
-    });
-    // Okay, now get rid of all edges that are defined by the
-    // involved nodes.
-    each(anchor.all_edges(), function(edge){
-	if(involved_node[edge.subject_id()] && involved_node[edge.object_id()]){
-	    anchor.remove_edge_by_id(edge.id());
-	}
-    });
+  // Since we can actually legally have an edge delete in the
+  // merge, let's go ahead and cycle through the "complete"
+  // graph and toss edges from individuals involved in the
+  // merge.
+  var involved_node = {};
+  each(in_graph.all_nodes(), function (node) {
+    involved_node[node.id()] = true;
+  });
+  // Okay, now get rid of all edges that are defined by the
+  // involved nodes.
+  each(anchor.all_edges(), function (edge) {
+    if (involved_node[edge.subject_id()] && involved_node[edge.object_id()]) {
+      anchor.remove_edge_by_id(edge.id());
+    }
+  });
 
-    // Blitz our old annotations as all new will be incoming (and
-    // the merge just takes the superset). Will be fine with fix:
-    // https://github.com/geneontology/minerva/issues/5
-    anchor.annotations([]);
+  // Blitz our old annotations as all new will be incoming (and
+  // the merge just takes the superset). Will be fine with fix:
+  // https://github.com/geneontology/minerva/issues/5
+  anchor.annotations([]);
 
-    var ret = anchor.merge_in(in_graph);
-    return ret;
+  var ret = anchor.merge_in(in_graph);
+  return ret;
 };
 
 /**
@@ -1394,63 +1408,63 @@ noctua_graph.prototype.merge_special = function(in_graph){
  * @param {graph} in_graph - the graph to update with
  * @returns {Boolean} if graph was loaded
  */
-noctua_graph.prototype.update_with = function(update_graph){
-    var anchor = this;
+noctua_graph.prototype.update_with = function (update_graph) {
+  var anchor = this;
 
-    // Prefer the new graph annotations by nuking the old.
-    anchor._annotations = [];
-    var update_graph_anns = update_graph.annotations();
-    each(update_graph_anns, function(ann){
-    	anchor.add_annotation(ann.clone());
+  // Prefer the new graph annotations by nuking the old.
+  anchor._annotations = [];
+  var update_graph_anns = update_graph.annotations();
+  each(update_graph_anns, function (ann) {
+    anchor.add_annotation(ann.clone());
+  });
+
+  // Next, look at individuals/nodes for addition or updating.
+  var updatable_nodes = {};
+  each(update_graph.all_nodes(), function (ind) {
+    // Update node by clobbering. This is preferred since deleting
+    // it would mean that all the connections would have to be
+    // reconstructed as well.
+    var update_node = anchor.get_node(ind.id());
+    if (update_node) {
+      //console.log('update node: ' + ind.id());
+    } else {
+      //console.log('add new node' + ind.id());
+    }
+    // Mark as a modified node.
+    updatable_nodes[ind.id()] = true;
+    // Add new node to edit core.
+    anchor.add_node(ind.clone());
+  });
+
+  // Now look at edges (by individual) for purging and
+  // reinstating--no going to try and update edges, just clobber.
+  each(update_graph.all_nodes(), function (source_node) {
+    //console.log('looking at node: ' + source_node.id());
+
+    // Look up what edges it has in /core/, as they will be the
+    // ones to update.
+    var snid = source_node.id();
+    var src_edges = anchor.get_edges_by_subject(snid);
+
+    // Delete all edges for said node in model. We cannot
+    // (apparently?) go from connection ID to connection easily,
+    // so removing from UI is a separate step.
+    each(src_edges, function (src_edge) {
+      // Remove from model.
+      var removed_p = anchor.remove_edge_by_id(src_edge.id());
+      //console.log('remove edge (' + removed_p + '): ' + src_edge.id());
     });
+  });
 
-    // Next, look at individuals/nodes for addition or updating.
-    var updatable_nodes = {};
-    each(update_graph.all_nodes(), function(ind){
-	// Update node by clobbering. This is preferred since deleting
-	// it would mean that all the connections would have to be
-	// reconstructed as well.
-	var update_node = anchor.get_node(ind.id());
-	if( update_node ){
-	    //console.log('update node: ' + ind.id());
-	}else{
-	    //console.log('add new node' + ind.id());
-	}
-	// Mark as a modified node.
-	updatable_nodes[ind.id()] = true;
-	// Add new node to edit core.
-	anchor.add_node(ind.clone());
-    });
+  // All edges should have IDs, so get them out of the graph if they
+  // are incoming.
+  each(update_graph.all_edges(), function (edge) {
+    var in_id = edge.id();
+    anchor.remove_edge_by_id(in_id);
+    anchor.add_edge(edge.clone());
+  });
 
-    // Now look at edges (by individual) for purging and
-    // reinstating--no going to try and update edges, just clobber.
-    each(update_graph.all_nodes(), function(source_node){
-    	//console.log('looking at node: ' + source_node.id());
-
-    	// Look up what edges it has in /core/, as they will be the
-    	// ones to update.
-    	var snid = source_node.id();
-    	var src_edges = anchor.get_edges_by_subject(snid);
-
-    	// Delete all edges for said node in model. We cannot
-    	// (apparently?) go from connection ID to connection easily,
-    	// so removing from UI is a separate step.
-    	each(src_edges, function(src_edge){
-    	    // Remove from model.
-    	    var removed_p = anchor.remove_edge_by_id(src_edge.id());
-    	    //console.log('remove edge (' + removed_p + '): ' + src_edge.id());
-    	});
-    });
-
-    // All edges should have IDs, so get them out of the graph if they
-    // are incoming.
-    each(update_graph.all_edges(), function(edge){
-	var in_id = edge.id();
-	anchor.remove_edge_by_id(in_id);
-	anchor.add_edge(edge.clone());
-    });
-
-    return true;
+  return true;
 };
 
 /**
@@ -1461,95 +1475,98 @@ noctua_graph.prototype.update_with = function(update_graph){
  * @param {Object} the "data" portion of a Minerva graph-related response.
  * @returns {Boolean} if data was loaded
  */
-noctua_graph.prototype.load_data_basic = function(data){
-    var anchor = this;
+noctua_graph.prototype.load_data_basic = function (data) {
+  var anchor = this;
 
-    var ret = false;
+  var ret = false;
 
-    if( data ){
-
-	// Add the graph metadata.
-	var graph_id = data['id'] || null;
-	var graph_anns = data['annotations'] || [];
-	if( graph_id ){ anchor.id(graph_id); }
-	if( ! us.isEmpty(graph_anns) ){
-	    each(graph_anns, function(ann_kv_set){
-		var na = new annotation(ann_kv_set);
-		anchor.add_annotation(na);
-	    });
-	}
-
-	// Add the additional metadata.
-	if( typeof(data['inconsistent-p']) !== 'undefined' ){
-	    anchor._inconsistent_p = data['inconsistent-p'];
-	}
-	if( typeof(data['modified-p']) !== 'undefined' ){
-	    anchor._modified_p = data['modified-p'];
-	}
-
-	// Validation/violation information. Currently, this will only
-	// be entered if the reasoner is on.
-	if( typeof(data['validation-results']) !== 'undefined' &&
-	    us.isObject(data['validation-results']) ){
-
-	    var vres = data['validation-results'];
-
-	    // Top level.
-	    if( us.isBoolean(vres['is-conformant']) ){
-		if( vres['is-conformant'] === true ){
-		    anchor._valid_p = true;
-		}else if( vres['is-conformant'] === false ){
-		    anchor._valid_p = false;
-		}
-	    }
-
-	    // OWL.
-	    if( vres['owl-validation'] && us.isObject(vres['owl-validation']) ){
-		if( vres['owl-validation']['is-conformant'] === true ){
-		    anchor._valid_owl_p = true;
-		}else if( vres['owl-validation']['is-conformant'] === false ){
-		    anchor._valid_owl_p = false;
-		}
-	    }
-
-	    // ShEx.
-	    if( vres['shex-validation'] && us.isObject(vres['shex-validation'])){
-		if( vres['shex-validation']['is-conformant'] === true ){
-		    anchor._valid_shex_p = true;
-		}else if( vres['shex-validation']['is-conformant'] === false ){
-		    anchor._valid_shex_p = false;
-		}
-	    }
-
-	    // Collect into violation objects; currently just ShEx.
-	    if( vres['shex-validation'] &&
-		us.isObject(vres['shex-validation']) &&
-		us.isArray(vres['shex-validation']['violations']) ){
-
-		var violations = vres['shex-validation']['violations'] || [];
-		each(violations, function(raw_v){
-		    var new_v = new violation(raw_v);
-		    anchor._violations.push(new_v);
-		});
-	    }
-	}
-
-	// Easy facts.
-	var facts = data['facts'];
-	each(facts, function(fact){
-	    anchor.add_edge_from_fact(fact);
-	});
-
-	// Build the structure of the graph in the most obvious way.
-	var inds = data['individuals'];
-	each(inds, function(ind){
-	    anchor.add_node_from_individual(ind);
-	});
-
-	ret = true;
+  if (data) {
+    // Add the graph metadata.
+    var graph_id = data["id"] || null;
+    var graph_anns = data["annotations"] || [];
+    if (graph_id) {
+      anchor.id(graph_id);
+    }
+    if (!us.isEmpty(graph_anns)) {
+      each(graph_anns, function (ann_kv_set) {
+        var na = new annotation(ann_kv_set);
+        anchor.add_annotation(na);
+      });
     }
 
-    return ret;
+    // Add the additional metadata.
+    if (typeof data["inconsistent-p"] !== "undefined") {
+      anchor._inconsistent_p = data["inconsistent-p"];
+    }
+    if (typeof data["modified-p"] !== "undefined") {
+      anchor._modified_p = data["modified-p"];
+    }
+
+    // Validation/violation information. Currently, this will only
+    // be entered if the reasoner is on.
+    if (
+      typeof data["validation-results"] !== "undefined" &&
+      us.isObject(data["validation-results"])
+    ) {
+      var vres = data["validation-results"];
+
+      // Top level.
+      if (us.isBoolean(vres["is-conformant"])) {
+        if (vres["is-conformant"] === true) {
+          anchor._valid_p = true;
+        } else if (vres["is-conformant"] === false) {
+          anchor._valid_p = false;
+        }
+      }
+
+      // OWL.
+      if (vres["owl-validation"] && us.isObject(vres["owl-validation"])) {
+        if (vres["owl-validation"]["is-conformant"] === true) {
+          anchor._valid_owl_p = true;
+        } else if (vres["owl-validation"]["is-conformant"] === false) {
+          anchor._valid_owl_p = false;
+        }
+      }
+
+      // ShEx.
+      if (vres["shex-validation"] && us.isObject(vres["shex-validation"])) {
+        if (vres["shex-validation"]["is-conformant"] === true) {
+          anchor._valid_shex_p = true;
+        } else if (vres["shex-validation"]["is-conformant"] === false) {
+          anchor._valid_shex_p = false;
+        }
+      }
+
+      // Collect into violation objects; currently just ShEx.
+      if (
+        vres["shex-validation"] &&
+        us.isObject(vres["shex-validation"]) &&
+        us.isArray(vres["shex-validation"]["violations"])
+      ) {
+        var violations = vres["shex-validation"]["violations"] || [];
+        each(violations, function (raw_v) {
+          var new_v = new violation(raw_v);
+          anchor._violations.push(new_v);
+        });
+      }
+    }
+
+    // Easy facts.
+    var facts = data["facts"];
+    each(facts, function (fact) {
+      anchor.add_edge_from_fact(fact);
+    });
+
+    // Build the structure of the graph in the most obvious way.
+    var inds = data["individuals"];
+    each(inds, function (ind) {
+      anchor.add_node_from_individual(ind);
+    });
+
+    ret = true;
+  }
+
+  return ret;
 };
 
 /**
@@ -1561,55 +1578,54 @@ noctua_graph.prototype.load_data_basic = function(data){
  *
  * @returns {Object} a map of seeds (by id) to their referencing enity {node} or {edge}
  */
-noctua_graph.prototype.extract_evidence_seeds = function(){
-    var anchor = this;
+noctua_graph.prototype.extract_evidence_seeds = function () {
+  var anchor = this;
 
-    // Take and, and see if it is an evidence reference.
-    function is_iri_ev_p(ann){
-	var ret = false;
-	if( ann.key() === 'evidence' && ann.value_type() === 'IRI' ){
-	    ret = true;
-	}
-	return ret;
+  // Take and, and see if it is an evidence reference.
+  function is_iri_ev_p(ann) {
+    var ret = false;
+    if (ann.key() === "evidence" && ann.value_type() === "IRI") {
+      ret = true;
     }
+    return ret;
+  }
 
-    // For any node, look at all of the annotations, and fold in
-    // ones that 1) pass the test and 2) reference a singleton
-    // node.
-    var seeds = {}; // collect all possibilities here
-    function pull_seeds(entity, test_p){
-	each(entity.annotations(), function(ann){
+  // For any node, look at all of the annotations, and fold in
+  // ones that 1) pass the test and 2) reference a singleton
+  // node.
+  var seeds = {}; // collect all possibilities here
+  function pull_seeds(entity, test_p) {
+    each(entity.annotations(), function (ann) {
+      //console.log(ann.key(), ann.value_type(), ann.value());
 
-	    //console.log(ann.key(), ann.value_type(), ann.value());
+      // Is it an evidence annotation.
+      if (!test_p(ann)) {
+        // Skip.
+        //console.log('skip folding with failed test');
+      } else {
+        //console.log('start folding with passed test');
 
-	    // Is it an evidence annotation.
-	    if( ! test_p(ann) ){
-		// Skip.
-		//console.log('skip folding with failed test');
-	    }else{
-		//console.log('start folding with passed test');
-
-		// If so, and the individual in question exists, it is
-		// the jumping off point for the evidence folding
-		// subgraph.
-		var ref_node_id = ann.value();
-		var ref_node = anchor.get_node(ref_node_id);
-		if( ref_node ){
-		    seeds[ref_node_id] = entity;
-		}
-	    }
-	});
-    }
-
-    // Cycle through everything and collect them.
-    each(anchor.all_nodes(), function(node){
-	pull_seeds(node, is_iri_ev_p);
+        // If so, and the individual in question exists, it is
+        // the jumping off point for the evidence folding
+        // subgraph.
+        var ref_node_id = ann.value();
+        var ref_node = anchor.get_node(ref_node_id);
+        if (ref_node) {
+          seeds[ref_node_id] = entity;
+        }
+      }
     });
-    each(anchor.all_edges(), function(edges){
-	pull_seeds(edges, is_iri_ev_p);
-    });
+  }
 
-    return seeds;
+  // Cycle through everything and collect them.
+  each(anchor.all_nodes(), function (node) {
+    pull_seeds(node, is_iri_ev_p);
+  });
+  each(anchor.all_edges(), function (edges) {
+    pull_seeds(edges, is_iri_ev_p);
+  });
+
+  return seeds;
 };
 
 /**
@@ -1623,21 +1639,21 @@ noctua_graph.prototype.extract_evidence_seeds = function(){
  * @param {String} node_id the ID of the see node in an evidence clique
  * @returns {graph} a list of found seeds as {node} ids
  */
-noctua_graph.prototype.get_evidence_clique = function(node_id){
-    var anchor = this;
+noctua_graph.prototype.get_evidence_clique = function (node_id) {
+  var anchor = this;
 
-    // Create the clique by grabbing all nodes and creating a walkable
-    // neighborhood.
-    var up = anchor.get_ancestor_subgraph(node_id);
-    //console.log("UP: ", up);
-    var down = anchor.get_descendent_subgraph(node_id);
-    //console.log("DOWN: ", down);
-    up.merge_in(down);
+  // Create the clique by grabbing all nodes and creating a walkable
+  // neighborhood.
+  var up = anchor.get_ancestor_subgraph(node_id);
+  //console.log("UP: ", up);
+  var down = anchor.get_descendent_subgraph(node_id);
+  //console.log("DOWN: ", down);
+  up.merge_in(down);
 
-    up.id(node_id);
+  up.id(node_id);
 
-    var ret = up;
-    return ret;
+  var ret = up;
+  return ret;
 };
 
 /**
@@ -1656,47 +1672,46 @@ noctua_graph.prototype.get_evidence_clique = function(node_id){
  * @param {String} node_id the ID of the seed node in an evidence clique - it is *assumed* that this is a legit seed node id
  * @returns {graph|null} a list of found seeds as {node} ids
  */
-noctua_graph.prototype.get_evidence_subclique = function(node_id){
-    var anchor = this;
+noctua_graph.prototype.get_evidence_subclique = function (node_id) {
+  var anchor = this;
 
-    var ret = null;
+  var ret = null;
 
-    // Must have a seed to start.
-    var seed_node = anchor.get_node(node_id);
-    if( seed_node ){
+  // Must have a seed to start.
+  var seed_node = anchor.get_node(node_id);
+  if (seed_node) {
+    // Start a new graph here. If this is the traditional simple
+    // GO model, we also stop here.
+    var ret_graph = anchor.create_graph();
+    ret_graph.id(node_id);
+    ret_graph.add_node(seed_node.clone());
 
-	// Start a new graph here. If this is the traditional simple
-	// GO model, we also stop here.
-	var ret_graph = anchor.create_graph();
-	ret_graph.id(node_id);
-	ret_graph.add_node(seed_node.clone());
+    // For more complicated PMID evidence, we need to walk a
+    // little deeper.
+    // Add the kids...
+    var kids = anchor.get_child_nodes(seed_node.id(), "IAO:0000136");
+    if (!us.isEmpty(kids)) {
+      each(kids, function (kid) {
+        var klone = kid.clone();
+        ret_graph.add_node(klone);
+      });
+      // ...and create new edges.
+      var keds = anchor.get_child_edges(seed_node.id(), "IAO:0000136");
+      each(keds, function (ked) {
+        var klone = ked.clone();
+        ret_graph.add_edge(klone);
+      });
 
-	// For more complicated PMID evidence, we need to walk a
-	// little deeper.
-	// Add the kids...
-	var kids = anchor.get_child_nodes(seed_node.id(), 'IAO:0000136');
-	if( ! us.isEmpty(kids) ){
-	    each(kids, function(kid){
-		var klone = kid.clone();
-		ret_graph.add_node(klone);
-	    });
-	    // ...and create new edges.
-	    var keds = anchor.get_child_edges(seed_node.id(), 'IAO:0000136');
-	    each(keds, function(ked){
-		var klone = ked.clone();
-		ret_graph.add_edge(klone);
-	    });
-
-	    // TODO: Dig down deeper from here for publication.
-	}
-
-	// TODO: Dig down deeper from here for non-publication.
-
-	// This is what we'll return.
-	ret = ret_graph;
+      // TODO: Dig down deeper from here for publication.
     }
 
-    return ret;
+    // TODO: Dig down deeper from here for non-publication.
+
+    // This is what we'll return.
+    ret = ret_graph;
+  }
+
+  return ret;
 };
 
 /**
@@ -1711,152 +1726,152 @@ noctua_graph.prototype.get_evidence_subclique = function(node_id){
  *
  * @returns {Boolean} if data was loaded
  */
-noctua_graph.prototype.fold_evidence = function(){
-    var anchor = this;
+noctua_graph.prototype.fold_evidence = function () {
+  var anchor = this;
 
-    var ret = false;
+  var ret = false;
 
-    // We are going to fold by clique.
-    var seeds = anchor.extract_evidence_seeds();
-    //console.log('seeds', us.keys(seeds));
+  // We are going to fold by clique.
+  var seeds = anchor.extract_evidence_seeds();
+  //console.log('seeds', us.keys(seeds));
 
-    // Get the cliques (super-neighborhood evidence) and get a map of
-    // what seeds are in each clique. Instead of comparing cliques to
-    // eliminate dupes (it's possible to have shared structure), we
-    // just keep checking the seeds, marking the ones that we've seen
-    // so we don't check again.
-    //
-    // This section produces a clique map and a clique to sed map.
-    //
-    var cliques = {}; // clique_id->clique
-    var clique_seed_map = {}; // clique_id->{seeds->true, in->true, clique->true}
-    var skippable_seeds = {}; // once we see a seed, we can skip it afterwards
-    each(seeds, function(referncing_entity, seed_id){
-	//console.log('seed_id', seed_id);
-	if( ! skippable_seeds[seed_id] ){ // skip uneeded ones
+  // Get the cliques (super-neighborhood evidence) and get a map of
+  // what seeds are in each clique. Instead of comparing cliques to
+  // eliminate dupes (it's possible to have shared structure), we
+  // just keep checking the seeds, marking the ones that we've seen
+  // so we don't check again.
+  //
+  // This section produces a clique map and a clique to sed map.
+  //
+  var cliques = {}; // clique_id->clique
+  var clique_seed_map = {}; // clique_id->{seeds->true, in->true, clique->true}
+  var skippable_seeds = {}; // once we see a seed, we can skip it afterwards
+  each(seeds, function (referncing_entity, seed_id) {
+    //console.log('seed_id', seed_id);
+    if (!skippable_seeds[seed_id]) {
+      // skip uneeded ones
 
-	    // Get clique.
-	    var clique = anchor.get_evidence_clique(seed_id);
-	    var clique_id = clique.id();
-	    //console.log(' clique_id', clique_id);
-	    //console.log(' clique', clique);
+      // Get clique.
+      var clique = anchor.get_evidence_clique(seed_id);
+      var clique_id = clique.id();
+      //console.log(' clique_id', clique_id);
+      //console.log(' clique', clique);
 
-	    // Ready clique map.
-	    clique_seed_map[clique_id] = {};
+      // Ready clique map.
+      clique_seed_map[clique_id] = {};
 
-	    //
-	    each(seeds, function(check_referencing_entity, check_seed_id){
-		if( ! skippable_seeds[check_seed_id] ){ // skip uneeded ones
-		    //console.log(' pass', check_seed_id);
+      //
+      each(seeds, function (check_referencing_entity, check_seed_id) {
+        if (!skippable_seeds[check_seed_id]) {
+          // skip uneeded ones
+          //console.log(' pass', check_seed_id);
 
-		    //
-		    if( clique.get_node(check_seed_id) ){
-			//console.log(' in clique:', check_seed_id);
+          //
+          if (clique.get_node(check_seed_id)) {
+            //console.log(' in clique:', check_seed_id);
 
-			// Add seed to map and skippable.
-			clique_seed_map[clique_id][check_seed_id] = true;
-			skippable_seeds[check_seed_id] = true;
-			cliques[clique_id] = clique;
-			// console.log('seed',check_seed_id,
-			// 	    '\n in clique',clique_id);
-		    }else{
-			// Pass.
-			// console.log('seed',check_seed_id,
-			// 	    'not in clique',clique_id);
-		    }
-		}
-	    });
-	}
+            // Add seed to map and skippable.
+            clique_seed_map[clique_id][check_seed_id] = true;
+            skippable_seeds[check_seed_id] = true;
+            cliques[clique_id] = clique;
+            // console.log('seed',check_seed_id,
+            // 	    '\n in clique',clique_id);
+          } else {
+            // Pass.
+            // console.log('seed',check_seed_id,
+            // 	    'not in clique',clique_id);
+          }
+        }
+      });
+    }
+  });
+
+  //console.log('cliques', cliques);
+  //console.log('cliques', us.keys(cliques));
+  //console.log('clique_seed_map', clique_seed_map);
+
+  // Okay, we will do the folding on a clique-by-clique basis. See
+  // the top of the file for rules.
+  each(cliques, function (clique, clique_id) {
+    //console.log('clique_id', clique_id);
+
+    // Nodes in the clique.
+    var clique_nodes = {};
+    each(clique.all_nodes(), function (cn) {
+      var cnid = cn.id();
+      clique_nodes[cnid] = true;
     });
 
-    //console.log('cliques', cliques);
-    //console.log('cliques', us.keys(cliques));
-    //console.log('clique_seed_map', clique_seed_map);
+    // Collect the subcliques for every clique.
+    var contained_seed_map = clique_seed_map[clique_id];
+    //console.log('csm', contained_seed_map);
+    var subcliques = {};
+    each(contained_seed_map, function (bool, seed_id) {
+      var subclique = anchor.get_evidence_clique(seed_id);
+      //console.log(subclique);
 
-    // Okay, we will do the folding on a clique-by-clique basis. See
-    // the top of the file for rules.
-    each(cliques, function(clique, clique_id){
+      // Add to cache of subcliques.
+      subcliques[seed_id] = subclique;
 
-	//console.log('clique_id', clique_id);
-
-	// Nodes in the clique.
-	var clique_nodes = {};
-	each(clique.all_nodes(), function(cn){
-	    var cnid = cn.id();
-	    clique_nodes[cnid] = true;
-	});
-
-	// Collect the subcliques for every clique.
-	var contained_seed_map = clique_seed_map[clique_id];
-	//console.log('csm', contained_seed_map);
-	var subcliques = {};
-	each(contained_seed_map, function(bool, seed_id){
-
-	    var subclique = anchor.get_evidence_clique(seed_id);
-	    //console.log(subclique);
-
-	    // Add to cache of subcliques.
-	    subcliques[seed_id] = subclique;
-
-	    // Mark out all of the clique_nodes seen.
-	    each(subclique.all_nodes(), function(sub_node){
-		var snid = sub_node.id();
-		if( clique_nodes[snid] ){
-		    delete clique_nodes[snid];
-		}
-	    });
-	});
-
-	//console.log('clique_nodes', clique_nodes);
-	//console.log('subcliques', subcliques);
-
-	// Okay, if the clique_nodes map is empty, that means it is
-	// completely covered by the subcliques and can be removed.
-	if( ! us.isEmpty(clique_nodes) ){
-	    //console.log(' cannot fold clique due to maigo no node');
-	}else{
-	    // Add subcliques to initial referring nodes.
-	    each(subcliques, function(subclique, seed_id){
-		// Make sure that we fold into the original node of
-		// the original graph.
-		var origin_entity = seeds[seed_id]; // still a copy
-		if( ! origin_entity ){
-		    // console.log('skip addition (possibly edge uuid)');
-		    // console.log('skip addition over (A)', seed_id);
-		    // console.log('skip addition over (B)',
-		    // 		origin_node_clone_maybe.id());
-		}else{
-		    // Since origin_entity is a copy, we'll modify it
-		    // and re-add it to the graph to make change
-		    // permanent.
-		    origin_entity.add_referenced_subgraph(subclique);
-		    // clobber non-ref version
-		    var entity_is =  bbop.what_is(origin_entity);
-		    //console.log(entity_is, entity_is);
-		    if( entity_is === 'bbop-graph-noctua.node' ){
-			anchor.add_node(origin_entity);
-		    }else if( entity_is === 'bbop-graph-noctua.edge' ){
-			anchor.add_edge(origin_entity);
-		    }else{
-			// Very Bad.
-			log('ERROR: attempt to clobber unknown entity');
-		    }
-		}
-	    });
-
-	    // Disolve the entire clique from graph, depending on edge
-	    // to auto-disolve.
-	    each(clique.all_nodes(), function(removable_cn, cni){
-		//console.log('remove', cni , removable_cn.id());
-		//console.log(anchor.remove_node(removable_cn.id(), true));
-		anchor.remove_node(removable_cn.id(), true);
-	    });
-	}
+      // Mark out all of the clique_nodes seen.
+      each(subclique.all_nodes(), function (sub_node) {
+        var snid = sub_node.id();
+        if (clique_nodes[snid]) {
+          delete clique_nodes[snid];
+        }
+      });
     });
 
-    ret = true;
+    //console.log('clique_nodes', clique_nodes);
+    //console.log('subcliques', subcliques);
 
-    return ret;
+    // Okay, if the clique_nodes map is empty, that means it is
+    // completely covered by the subcliques and can be removed.
+    if (!us.isEmpty(clique_nodes)) {
+      //console.log(' cannot fold clique due to maigo no node');
+    } else {
+      // Add subcliques to initial referring nodes.
+      each(subcliques, function (subclique, seed_id) {
+        // Make sure that we fold into the original node of
+        // the original graph.
+        var origin_entity = seeds[seed_id]; // still a copy
+        if (!origin_entity) {
+          // console.log('skip addition (possibly edge uuid)');
+          // console.log('skip addition over (A)', seed_id);
+          // console.log('skip addition over (B)',
+          // 		origin_node_clone_maybe.id());
+        } else {
+          // Since origin_entity is a copy, we'll modify it
+          // and re-add it to the graph to make change
+          // permanent.
+          origin_entity.add_referenced_subgraph(subclique);
+          // clobber non-ref version
+          var entity_is = bbop.what_is(origin_entity);
+          //console.log(entity_is, entity_is);
+          if (entity_is === "bbop-graph-noctua.node") {
+            anchor.add_node(origin_entity);
+          } else if (entity_is === "bbop-graph-noctua.edge") {
+            anchor.add_edge(origin_entity);
+          } else {
+            // Very Bad.
+            log("ERROR: attempt to clobber unknown entity");
+          }
+        }
+      });
+
+      // Disolve the entire clique from graph, depending on edge
+      // to auto-disolve.
+      each(clique.all_nodes(), function (removable_cn, cni) {
+        //console.log('remove', cni , removable_cn.id());
+        //console.log(anchor.remove_node(removable_cn.id(), true));
+        anchor.remove_node(removable_cn.id(), true);
+      });
+    }
+  });
+
+  ret = true;
+
+  return ret;
 };
 
 /**
@@ -1872,141 +1887,142 @@ noctua_graph.prototype.fold_evidence = function(){
  * @param {Array} relation_reverse_list of relations (as strings) to scan for for collapsing in the opposite direction.
  * @returns {Boolean} if data was loaded
  */
-noctua_graph.prototype.fold_go_noctua = function(relation_list,
-						 relation_reverse_list){
-    var anchor = this;
+noctua_graph.prototype.fold_go_noctua = function (relation_list, relation_reverse_list) {
+  var anchor = this;
 
-    // Start out with the evidence folded graph.
-    var ret = anchor.fold_evidence();
-    if( ! ret ){ return false; } // Early bail on bad upstream.
+  // Start out with the evidence folded graph.
+  var ret = anchor.fold_evidence();
+  if (!ret) {
+    return false;
+  } // Early bail on bad upstream.
 
-    // It is foldable if it is a root node (re: opposite of leaf--only
-    // target) and if it only has the one child (no way out--re: collapsible ).
-    function _foldable_p(node){
-	var ret = false;
-	// console.log("  " + dd(node.id()));
-	if( anchor.is_root_node(node.id()) &&
-	    ! node.subgraph() && // cannot fold if already folded into
-	    anchor.get_child_nodes(node.id()).length === 1 ){
-		// console.log("    Y root_p: " +
-		// 	    anchor.is_root_node(node.id()) +
-		// 	    ";  kids: " +
-		// 	    anchor.get_child_nodes(node.id()).length);
-		ret = true;
-	    }else{
-		// console.log("    N root_p: " +
-		// 	    anchor.is_root_node(node.id()) +
-		// 	    ";  kids: " +
-		// 	    anchor.get_child_nodes(node.id()).length);
-	    }
-	return ret;
+  // It is foldable if it is a root node (re: opposite of leaf--only
+  // target) and if it only has the one child (no way out--re: collapsible ).
+  function _foldable_p(node) {
+    var ret = false;
+    // console.log("  " + dd(node.id()));
+    if (
+      anchor.is_root_node(node.id()) &&
+      !node.subgraph() && // cannot fold if already folded into
+      anchor.get_child_nodes(node.id()).length === 1
+    ) {
+      // console.log("    Y root_p: " +
+      // 	    anchor.is_root_node(node.id()) +
+      // 	    ";  kids: " +
+      // 	    anchor.get_child_nodes(node.id()).length);
+      ret = true;
+    } else {
+      // console.log("    N root_p: " +
+      // 	    anchor.is_root_node(node.id()) +
+      // 	    ";  kids: " +
+      // 	    anchor.get_child_nodes(node.id()).length);
     }
-
-    // It is reverse foldable if it is a leaf node (re: opposite of
-    // root--only source) and if it only has the one child (no way
-    // out--re: collapsible ).
-    function _reverse_foldable_p(node){
-	var ret = false;
-	if( anchor.is_leaf_node(node.id()) &&
-	    ! node.subgraph() && // cannot fold if already folded into
-	    anchor.get_parent_nodes(node.id()).length === 1 ){
-		//console.log("is foldable: " + node.id());
-		ret = true;
-	    }else{
-		//console.log("not foldable: " + node.id());
-	    }
-	// console.log("  leaf_p: " + anchor.is_leaf_node(node.id()) +
-	// 	    ";  parents: " + anchor.get_parent_nodes(node.id()).length);
-	return ret;
-    }
-
-    // Okay, first scan all nodes for our pattern.
-    // each(anchor.all_nodes(), function(pattern_seed_indv){
-    // Temporarily enforce an ordering so we can debug/have consistent
-    // results.
-    var todo_nodes = anchor.all_nodes();
-    todo_nodes = todo_nodes.sort(function(a,b){
-	//console.log(a.id()+' vs. '+ b.id() +': '+a.id().localeCompare(b.id()));
-	return a.id().localeCompare(b.id());
-    });
-    each(todo_nodes, function(pattern_seed_indv){
-	//console.log( dd(pattern_seed_indv.id()) );
-
-	var pattern_seed_id = pattern_seed_indv.id();
-
-	// The possible base subgraph (seeding with current node--note
-	// the clone so we don't have infinite recursion) we might
-	// capture.
-	var subgraph = anchor.create_graph();
-	subgraph.add_node(pattern_seed_indv.clone());
-
-	// Fold checking is independent of reverse or not.
-	var fold_occurred_p = false;
-
-	// Check a set of relations for completeness.
-	var collapsable_relations = relation_list || [];
-	each(collapsable_relations, function(relation){
-
-	    var parents = anchor.get_parent_nodes(pattern_seed_id, relation);
-	    each(parents, function(parent){
-
-		if( _foldable_p(parent) ){
-		    fold_occurred_p = true;
-
-		    // Preserve it and its edge in the new subgraph.
-		    var p = parent.clone();
-		    // if( p.subgraph() ){
-		    // 	console.log('  has SUB');
-		    // }
-		    subgraph.add_node(p);
-		    var eta = anchor.get_edge(pattern_seed_id, p.id(), relation);
-		    subgraph.add_edge(eta.clone());
-		    // subgraph.report_state();
-
-		    // Remove same from the original graph, edge will be
-		    // destroyed in the halo.
-		    anchor.remove_node(parent.id(), true);
-		    // console.log('  *destroyed: ' + dd(parent.id()) );
-		}
-	    });
-	});
-
-	// ...and now the other way.
-	var collapsable_reverse_relations = relation_reverse_list || [];
-	each(collapsable_reverse_relations, function(relation){
-
-	    var children = anchor.get_child_nodes(pattern_seed_id, relation);
-	    each(children, function(child){
-
-		if( _reverse_foldable_p(child) ){
-		    fold_occurred_p = true;
-
-		    // Preserve it and its edge in the new subgraph.
-		    subgraph.add_node(child.clone());
-		    subgraph.add_edge( // we know it's just one from above
-			anchor.get_child_edges(pattern_seed_id,
-					       relation)[0].clone());
-
-		    // Remove same from the original graph, edge will
-		    // be destroyed in the halo.
-		    anchor.remove_node(child.id(), true);
-		}
-	    });
-	});
-
-	// A usable folding subgraph only occurred when the are more
-	// than 1 node in it; i.e. we actually actually added things
-	// to our local subgraph and removed them from the master
-	// graph.
-	if( fold_occurred_p ){
-	    // console.log('slurpable subgraph ('+ subgraph.all_nodes().length +
-	    // 		') for: ' + pattern_seed_id);
-	    pattern_seed_indv.subgraph(subgraph);
-	}
-
-    });
-
     return ret;
+  }
+
+  // It is reverse foldable if it is a leaf node (re: opposite of
+  // root--only source) and if it only has the one child (no way
+  // out--re: collapsible ).
+  function _reverse_foldable_p(node) {
+    var ret = false;
+    if (
+      anchor.is_leaf_node(node.id()) &&
+      !node.subgraph() && // cannot fold if already folded into
+      anchor.get_parent_nodes(node.id()).length === 1
+    ) {
+      //console.log("is foldable: " + node.id());
+      ret = true;
+    } else {
+      //console.log("not foldable: " + node.id());
+    }
+    // console.log("  leaf_p: " + anchor.is_leaf_node(node.id()) +
+    // 	    ";  parents: " + anchor.get_parent_nodes(node.id()).length);
+    return ret;
+  }
+
+  // Okay, first scan all nodes for our pattern.
+  // each(anchor.all_nodes(), function(pattern_seed_indv){
+  // Temporarily enforce an ordering so we can debug/have consistent
+  // results.
+  var todo_nodes = anchor.all_nodes();
+  todo_nodes = todo_nodes.sort(function (a, b) {
+    //console.log(a.id()+' vs. '+ b.id() +': '+a.id().localeCompare(b.id()));
+    return a.id().localeCompare(b.id());
+  });
+  each(todo_nodes, function (pattern_seed_indv) {
+    //console.log( dd(pattern_seed_indv.id()) );
+
+    var pattern_seed_id = pattern_seed_indv.id();
+
+    // The possible base subgraph (seeding with current node--note
+    // the clone so we don't have infinite recursion) we might
+    // capture.
+    var subgraph = anchor.create_graph();
+    subgraph.add_node(pattern_seed_indv.clone());
+
+    // Fold checking is independent of reverse or not.
+    var fold_occurred_p = false;
+
+    // Check a set of relations for completeness.
+    var collapsable_relations = relation_list || [];
+    each(collapsable_relations, function (relation) {
+      var parents = anchor.get_parent_nodes(pattern_seed_id, relation);
+      each(parents, function (parent) {
+        if (_foldable_p(parent)) {
+          fold_occurred_p = true;
+
+          // Preserve it and its edge in the new subgraph.
+          var p = parent.clone();
+          // if( p.subgraph() ){
+          // 	console.log('  has SUB');
+          // }
+          subgraph.add_node(p);
+          var eta = anchor.get_edge(pattern_seed_id, p.id(), relation);
+          subgraph.add_edge(eta.clone());
+          // subgraph.report_state();
+
+          // Remove same from the original graph, edge will be
+          // destroyed in the halo.
+          anchor.remove_node(parent.id(), true);
+          // console.log('  *destroyed: ' + dd(parent.id()) );
+        }
+      });
+    });
+
+    // ...and now the other way.
+    var collapsable_reverse_relations = relation_reverse_list || [];
+    each(collapsable_reverse_relations, function (relation) {
+      var children = anchor.get_child_nodes(pattern_seed_id, relation);
+      each(children, function (child) {
+        if (_reverse_foldable_p(child)) {
+          fold_occurred_p = true;
+
+          // Preserve it and its edge in the new subgraph.
+          subgraph.add_node(child.clone());
+          subgraph.add_edge(
+            // we know it's just one from above
+            anchor.get_child_edges(pattern_seed_id, relation)[0].clone(),
+          );
+
+          // Remove same from the original graph, edge will
+          // be destroyed in the halo.
+          anchor.remove_node(child.id(), true);
+        }
+      });
+    });
+
+    // A usable folding subgraph only occurred when the are more
+    // than 1 node in it; i.e. we actually actually added things
+    // to our local subgraph and removed them from the master
+    // graph.
+    if (fold_occurred_p) {
+      // console.log('slurpable subgraph ('+ subgraph.all_nodes().length +
+      // 		') for: ' + pattern_seed_id);
+      pattern_seed_indv.subgraph(subgraph);
+    }
+  });
+
+  return ret;
 };
 
 /**
@@ -2016,84 +2032,80 @@ noctua_graph.prototype.fold_go_noctua = function(relation_list,
  * @param {Object} [incoming_graph] subgraph to unfold into the calling graph (default behaviour would be calling itself; only really used internally by this method for recursion)
  * @returns {Boolean} if unfolded (should always be true)
  */
-noctua_graph.prototype.unfold = function(incoming_graph){
-    var anchor = this;
+noctua_graph.prototype.unfold = function (incoming_graph) {
+  var anchor = this;
 
-    // If not a recursive, we will operate on ourselves.
-    if( ! incoming_graph ){
-    	incoming_graph = anchor;
-    }
+  // If not a recursive, we will operate on ourselves.
+  if (!incoming_graph) {
+    incoming_graph = anchor;
+  }
 
-    // For any entity, remove its referenced individuals and re-add
-    // them to the graph.
-    function _unfold_subgraph(sub){
+  // For any entity, remove its referenced individuals and re-add
+  // them to the graph.
+  function _unfold_subgraph(sub) {
+    // Restore to graph.
+    // console.log('   unfold # (' + sub.all_nodes().length + ', ' +
+    // 	    sub.all_edges().length + ')');
+    each(sub.all_nodes(), function (node) {
+      anchor.add_node(node);
+    });
+    each(sub.all_edges(), function (edge) {
+      anchor.add_edge(edge);
+    });
+  }
 
-	// Restore to graph.
-	// console.log('   unfold # (' + sub.all_nodes().length + ', ' +
-	// 	    sub.all_edges().length + ')');
-	each(sub.all_nodes(), function(node){
-	    anchor.add_node(node);
-	});
-	each(sub.all_edges(), function(edge){
-	    anchor.add_edge(edge);
-	});
-    }
+  // Apply to all nodes.
+  each(incoming_graph.all_nodes(), function (node) {
+    // Get references (ev).
+    var ref_graphs = node.referenced_subgraphs();
 
-    // Apply to all nodes.
-    each(incoming_graph.all_nodes(), function(node){
-
-	// Get references (ev).
-	var ref_graphs = node.referenced_subgraphs();
-
-	// Restore to graph.
-	each(ref_graphs, function(sub){
-	    _unfold_subgraph(sub);
-	});
-
-	// Remove references.
-	node.referenced_subgraphs([]);
-
-	// Now that they've been removed (to help prevent loops) try
-	// and recur.
-	each(ref_graphs, function(sub){
-	    anchor.unfold(sub);
-	});
-
-	// Repeat with any absorbed subgraph.
-	var asub = node.subgraph();
-	if( asub ){
-	    _unfold_subgraph(asub);
-	    node.subgraph(null); // eliminate after it has been re-added
-	    // Recur on any found subgraphs, safer since the elimination.
-	    anchor.unfold(asub);
-	}
-
+    // Restore to graph.
+    each(ref_graphs, function (sub) {
+      _unfold_subgraph(sub);
     });
 
-    // Apply to all edges.
-    each(incoming_graph.all_edges(), function(edge){
+    // Remove references.
+    node.referenced_subgraphs([]);
 
-	// Get references (ev).
-	var ref_graphs = edge.referenced_subgraphs();
-
-	// Restore to graph.
-	each(ref_graphs, function(sub){
-	    _unfold_subgraph(sub);
-	});
-
-	// Remove references.
-	edge.referenced_subgraphs([]);
-
-	// Now that they've been removed, try and recur (to help
-	// prevent loops).
-	each(ref_graphs, function(sub){
-	    anchor.unfold(sub);
-	});
+    // Now that they've been removed (to help prevent loops) try
+    // and recur.
+    each(ref_graphs, function (sub) {
+      anchor.unfold(sub);
     });
 
-    // Revisit if we want something meaningful out of here.
-    var retval = true;
-    return retval;
+    // Repeat with any absorbed subgraph.
+    var asub = node.subgraph();
+    if (asub) {
+      _unfold_subgraph(asub);
+      node.subgraph(null); // eliminate after it has been re-added
+      // Recur on any found subgraphs, safer since the elimination.
+      anchor.unfold(asub);
+    }
+  });
+
+  // Apply to all edges.
+  each(incoming_graph.all_edges(), function (edge) {
+    // Get references (ev).
+    var ref_graphs = edge.referenced_subgraphs();
+
+    // Restore to graph.
+    each(ref_graphs, function (sub) {
+      _unfold_subgraph(sub);
+    });
+
+    // Remove references.
+    edge.referenced_subgraphs([]);
+
+    // Now that they've been removed, try and recur (to help
+    // prevent loops).
+    each(ref_graphs, function (sub) {
+      anchor.unfold(sub);
+    });
+  });
+
+  // Revisit if we want something meaningful out of here.
+  var retval = true;
+  return retval;
 };
 
 /**
@@ -2102,101 +2114,112 @@ noctua_graph.prototype.unfold = function(incoming_graph){
  *
  * @returns {null} just the facts
  */
-noctua_graph.prototype.report_state = function(incoming_graph, indentation){
-    var anchor = this;
+noctua_graph.prototype.report_state = function (incoming_graph, indentation) {
+  var anchor = this;
 
-    // If not a recursive, we will operate on ourselves.
-    if( ! incoming_graph ){
-    	incoming_graph = anchor;
-    }
+  // If not a recursive, we will operate on ourselves.
+  if (!incoming_graph) {
+    incoming_graph = anchor;
+  }
 
-    // Start with no indentation.
-    if( typeof(indentation) === 'undefined' ){
-    	indentation = 0;
-    }
+  // Start with no indentation.
+  if (typeof indentation === "undefined") {
+    indentation = 0;
+  }
 
-    // Collect spacing for this indentation level of logging.
-    var spacing = '';
-    for( var i = 0; i < indentation; i++ ){
-	spacing += '   ';
-    }
-    function ll(str){
-	log(spacing + str);
-    }
-    function short(str){
-	return str.substr(str.length - 16);
-    }
+  // Collect spacing for this indentation level of logging.
+  var spacing = "";
+  for (var i = 0; i < indentation; i++) {
+    spacing += "   ";
+  }
+  function ll(str) {
+    log(spacing + str);
+  }
+  function short(str) {
+    return str.substr(str.length - 16);
+  }
 
-    // Restore to graph.
-    var gid = incoming_graph.id() || '(anonymous graph)';
-    ll(gid);
-    ll(' entities # (' + incoming_graph.all_nodes().length +
-       ', ' + incoming_graph.all_edges().length + ')');
+  // Restore to graph.
+  var gid = incoming_graph.id() || "(anonymous graph)";
+  ll(gid);
+  ll(
+    " entities # (" +
+      incoming_graph.all_nodes().length +
+      ", " +
+      incoming_graph.all_edges().length +
+      ")",
+  );
 
-    // Show node information, arbitrary, but fixed, order.
-    each(incoming_graph.all_nodes().sort(function(a,b){
-	if( a.id() > b.id() ){
-	    return 1;
-	}else if( a.id() < b.id() ){
-	    return -1;
-	}
-	return 0;
-    }), function(node){
-	ll(' node: ' + dd(node.id()));
+  // Show node information, arbitrary, but fixed, order.
+  each(
+    incoming_graph.all_nodes().sort(function (a, b) {
+      if (a.id() > b.id()) {
+        return 1;
+      } else if (a.id() < b.id()) {
+        return -1;
+      }
+      return 0;
+    }),
+    function (node) {
+      ll(" node: " + dd(node.id()));
 
-	// Subgraph.
-	var subgraph = node.subgraph();
-	if( subgraph ){
-	    ll('  subgraph: ');
-	    anchor.report_state(subgraph, indentation +1);
-	}
+      // Subgraph.
+      var subgraph = node.subgraph();
+      if (subgraph) {
+        ll("  subgraph: ");
+        anchor.report_state(subgraph, indentation + 1);
+      }
 
-	// Refs.
-	var ref_graphs = node.referenced_subgraphs();
-	if( ref_graphs.length > 0 ){
-	    ll('  references: ');
-	    each(ref_graphs, function(sub){
-		anchor.report_state(sub, (indentation +1));
-	    });
-	}
-    });
+      // Refs.
+      var ref_graphs = node.referenced_subgraphs();
+      if (ref_graphs.length > 0) {
+        ll("  references: ");
+        each(ref_graphs, function (sub) {
+          anchor.report_state(sub, indentation + 1);
+        });
+      }
+    },
+  );
 
-    // Show edge information, arbitrary, but fixed, order.
-    each(incoming_graph.all_edges().sort(function(a,b){
-	if( a.id() > b.id() ){
-	    return 1;
-	}else if( a.id() < b.id() ){
-	    return -1;
-	}
-	return 0;
-    }), function(edge){
-	var s = dd(edge.subject_id());
-	var o = dd(edge.object_id());
-	var p = dd(edge.predicate_id());
-	//ll(' edge: ' + edge.id());
-	ll(' edge: ' + s + ', ' + o + ': ' + p);
+  // Show edge information, arbitrary, but fixed, order.
+  each(
+    incoming_graph.all_edges().sort(function (a, b) {
+      if (a.id() > b.id()) {
+        return 1;
+      } else if (a.id() < b.id()) {
+        return -1;
+      }
+      return 0;
+    }),
+    function (edge) {
+      var s = dd(edge.subject_id());
+      var o = dd(edge.object_id());
+      var p = dd(edge.predicate_id());
+      //ll(' edge: ' + edge.id());
+      ll(" edge: " + s + ", " + o + ": " + p);
 
-	// Refs.
-	var ref_graphs = edge.referenced_subgraphs();
-	if( ref_graphs.length > 0 ){
-	    ll('  references: ');
-	    each(ref_graphs, function(sub){
-		anchor.report_state(sub, (indentation +1));
-	    });
-	}
-    });
+      // Refs.
+      var ref_graphs = edge.referenced_subgraphs();
+      if (ref_graphs.length > 0) {
+        ll("  references: ");
+        each(ref_graphs, function (sub) {
+          anchor.report_state(sub, indentation + 1);
+        });
+      }
+    },
+  );
 
-    if( ! us.isEmpty(incoming_graph._os_table) ){
-	log(spacing + 'OS:', incoming_graph._os_table);
-    }
-    if( ! us.isEmpty(incoming_graph._so_table) ){
-	log(spacing + 'SO:', incoming_graph._so_table);
-    }
-    if( ! us.isEmpty(incoming_graph._predicates) ){
-	log(spacing + 'PRED:', incoming_graph._predicates);
-    }
+  if (!us.isEmpty(incoming_graph._os_table)) {
+    log(spacing + "OS:", incoming_graph._os_table);
+  }
+  if (!us.isEmpty(incoming_graph._so_table)) {
+    log(spacing + "SO:", incoming_graph._so_table);
+  }
+  if (!us.isEmpty(incoming_graph._predicates)) {
+    log(spacing + "PRED:", incoming_graph._predicates);
+  }
 
-    return null;
+  return null;
 };
 
 ///
@@ -2216,60 +2239,67 @@ var bbop_node = bbop_model.node;
  * @param {Array} [in_inferred_types] - list of Objects or strings--anything that can be parsed by class_expression
  * @returns {this}
  */
-function noctua_node(in_id, in_label, in_types, in_root_types, in_inferred_types, in_inferred_types_with_all){
-    bbop_node.call(this, in_id, in_label);
-    this._is_a = 'bbop-graph-noctua.node';
-    var anchor = this;
+function noctua_node(
+  in_id,
+  in_label,
+  in_types,
+  in_root_types,
+  in_inferred_types,
+  in_inferred_types_with_all,
+) {
+  bbop_node.call(this, in_id, in_label);
+  this._is_a = "bbop-graph-noctua.node";
+  var anchor = this;
 
-    // Let's make this an OWL-like world.
-    this._types = [];
-    this._id2type = {}; // contains map to both types and inferred types
-    this._root_types = [];
-    this._inferred_types = [];
-    this._inferred_types_with_all = [];
-    this._annotations = [];
-    this._referenced_subgraphs = [];
-    this._embedded_subgraph = null;
+  // Let's make this an OWL-like world.
+  this._types = [];
+  this._id2type = {}; // contains map to both types and inferred types
+  this._root_types = [];
+  this._inferred_types = [];
+  this._inferred_types_with_all = [];
+  this._annotations = [];
+  this._referenced_subgraphs = [];
+  this._embedded_subgraph = null;
 
-    // Incoming ID or generate ourselves.
-    if( typeof(in_id) === 'undefined' ){
-	this._id = bbop.uuid();
-    }else{
-	this._id = in_id;
-    }
+  // Incoming ID or generate ourselves.
+  if (typeof in_id === "undefined") {
+    this._id = bbop.uuid();
+  } else {
+    this._id = in_id;
+  }
 
-    // Roll in any types that we may have coming in.
-    if( us.isArray(in_types) ){
-	each(in_types, function(in_type){
-	    var new_type = new class_expression(in_type);
-	    anchor._id2type[new_type.id()] = new_type;
-	    anchor._types.push(new class_expression(in_type));
-	});
-    }
-    // Same with root types.
-    if( us.isArray(in_root_types) ){
-	each(in_root_types, function(in_root_type){
-	    var new_root_type = new class_expression(in_root_type);
-	    anchor._id2type[new_root_type.id()] = new_root_type;
-	    anchor._root_types.push(new class_expression(in_root_type));
-	});
-    }
-    // Same with inferred types.
-    if( us.isArray(in_inferred_types) ){
-	each(in_inferred_types, function(in_inferred_type){
-	    var new_type = new class_expression(in_inferred_type);
-	    anchor._id2type[new_type.id()] = new_type;
-	    anchor._inferred_types.push(new class_expression(in_inferred_type));
-	});
-    }
-    // Same with inferred types with all.
-    if( us.isArray(in_inferred_types_with_all) ){
-	each(in_inferred_types_with_all, function(in_inferred_type_with_all){
-	    var new_type = new class_expression(in_inferred_type_with_all);
-	    anchor._id2type[new_type.id()] = new_type;
-	    anchor._inferred_types_with_all.push(new class_expression(in_inferred_type_with_all));
-	});
-    }
+  // Roll in any types that we may have coming in.
+  if (us.isArray(in_types)) {
+    each(in_types, function (in_type) {
+      var new_type = new class_expression(in_type);
+      anchor._id2type[new_type.id()] = new_type;
+      anchor._types.push(new class_expression(in_type));
+    });
+  }
+  // Same with root types.
+  if (us.isArray(in_root_types)) {
+    each(in_root_types, function (in_root_type) {
+      var new_root_type = new class_expression(in_root_type);
+      anchor._id2type[new_root_type.id()] = new_root_type;
+      anchor._root_types.push(new class_expression(in_root_type));
+    });
+  }
+  // Same with inferred types.
+  if (us.isArray(in_inferred_types)) {
+    each(in_inferred_types, function (in_inferred_type) {
+      var new_type = new class_expression(in_inferred_type);
+      anchor._id2type[new_type.id()] = new_type;
+      anchor._inferred_types.push(new class_expression(in_inferred_type));
+    });
+  }
+  // Same with inferred types with all.
+  if (us.isArray(in_inferred_types_with_all)) {
+    each(in_inferred_types_with_all, function (in_inferred_type_with_all) {
+      var new_type = new class_expression(in_inferred_type_with_all);
+      anchor._id2type[new_type.id()] = new_type;
+      anchor._inferred_types_with_all.push(new class_expression(in_inferred_type_with_all));
+    });
+  }
 }
 bbop.extend(noctua_node, bbop_node);
 
@@ -2279,36 +2309,40 @@ bbop.extend(noctua_node, bbop_node);
  *
  * @returns {node} node
  */
-noctua_node.prototype.clone = function(){
-    var anchor = this;
+noctua_node.prototype.clone = function () {
+  var anchor = this;
 
-    // Fresh.
-    var new_clone = new noctua_node(anchor.id(), anchor.label(), anchor.types(),
-				    anchor.root_types(),
-				    anchor.inferred_types(),
-				    anchor.inferred_types_with_all());
+  // Fresh.
+  var new_clone = new noctua_node(
+    anchor.id(),
+    anchor.label(),
+    anchor.types(),
+    anchor.root_types(),
+    anchor.inferred_types(),
+    anchor.inferred_types_with_all(),
+  );
 
-    // Base class stuff.
-    new_clone.type(this.type());
-    new_clone.metadata(bbop.clone(this.metadata()));
+  // Base class stuff.
+  new_clone.type(this.type());
+  new_clone.metadata(bbop.clone(this.metadata()));
 
-    // Transfer over the new goodies, starting with annotations and
-    // referenced individuals.
-    each(anchor._annotations, function(annotation){
-	new_clone._annotations.push(annotation.clone());
-    });
-    each(anchor._referenced_subgraphs, function(sub){
-	new_clone._referenced_subgraphs.push(sub.clone());
-    });
+  // Transfer over the new goodies, starting with annotations and
+  // referenced individuals.
+  each(anchor._annotations, function (annotation) {
+    new_clone._annotations.push(annotation.clone());
+  });
+  each(anchor._referenced_subgraphs, function (sub) {
+    new_clone._referenced_subgraphs.push(sub.clone());
+  });
 
-    // Embedded subgraph.
-    if( anchor._embedded_subgraph ){
-	new_clone._embedded_subgraph = anchor._embedded_subgraph.clone();
-    }else{
-	new_clone._embedded_subgraph = null;
-    }
+  // Embedded subgraph.
+  if (anchor._embedded_subgraph) {
+    new_clone._embedded_subgraph = anchor._embedded_subgraph.clone();
+  } else {
+    new_clone._embedded_subgraph = null;
+  }
 
-    return new_clone;
+  return new_clone;
 };
 
 /**
@@ -2317,9 +2351,9 @@ noctua_node.prototype.clone = function(){
  * Parameters:
  * @returns {Array} array of types
  */
-noctua_node.prototype.types = function(){
-    var anchor = this;
-    return this._types;
+noctua_node.prototype.types = function () {
+  var anchor = this;
+  return this._types;
 };
 
 /**
@@ -2328,9 +2362,9 @@ noctua_node.prototype.types = function(){
  * Parameters:
  * @returns {Array} array of types
  */
-noctua_node.prototype.root_types = function(){
-    var anchor = this;
-    return this._root_types;
+noctua_node.prototype.root_types = function () {
+  var anchor = this;
+  return this._root_types;
 };
 
 /**
@@ -2339,9 +2373,9 @@ noctua_node.prototype.root_types = function(){
  * Parameters:
  * @returns {Array} array of types
  */
-noctua_node.prototype.inferred_types = function(){
-    var anchor = this;
-    return this._inferred_types;
+noctua_node.prototype.inferred_types = function () {
+  var anchor = this;
+  return this._inferred_types;
 };
 
 /**
@@ -2350,9 +2384,9 @@ noctua_node.prototype.inferred_types = function(){
  * Parameters:
  * @returns {Array} array of types
  */
-noctua_node.prototype.inferred_types_with_all = function(){
-    var anchor = this;
-    return this._inferred_types_with_all;
+noctua_node.prototype.inferred_types_with_all = function () {
+  var anchor = this;
+  return this._inferred_types_with_all;
 };
 
 /**
@@ -2363,28 +2397,28 @@ noctua_node.prototype.inferred_types_with_all = function(){
  * @param {Boolean} inferred_p - whether or not the argument types are inferred
  * @returns {Boolean} t|f
  */
-noctua_node.prototype.add_types = function(in_types, inferred_p){
-    var anchor = this;
-    var inf_p = inferred_p || false;
+noctua_node.prototype.add_types = function (in_types, inferred_p) {
+  var anchor = this;
+  var inf_p = inferred_p || false;
 
-    var ret = false;
+  var ret = false;
 
-    if( us.isArray(in_types) ){
-	each(in_types, function(in_type){
-	    var new_type = new class_expression(in_type);
-	    anchor._id2type[new_type.id()] = new_type;
-	    if( ! inferred_p ){
-		anchor._types.push(new_type);
-	    }else{
-		anchor._inferred_types.push(new_type);
-		// And with_all, as it is a superset.
-		anchor._inferred_types_with_all.push(new_type);
-	    }
+  if (us.isArray(in_types)) {
+    each(in_types, function (in_type) {
+      var new_type = new class_expression(in_type);
+      anchor._id2type[new_type.id()] = new_type;
+      if (!inferred_p) {
+        anchor._types.push(new_type);
+      } else {
+        anchor._inferred_types.push(new_type);
+        // And with_all, as it is a superset.
+        anchor._inferred_types_with_all.push(new_type);
+      }
 
-	    ret = true; // return true if did something
-	});
-    }
-    return ret;
+      ret = true; // return true if did something
+    });
+  }
+  return ret;
 };
 
 /**
@@ -2394,13 +2428,13 @@ noctua_node.prototype.add_types = function(in_types, inferred_p){
  * @param {String} type_id - type id
  * @returns {type|null} type or null
  */
-noctua_node.prototype.get_type_by_id = function(type_id){
-    var anchor = this;
+noctua_node.prototype.get_type_by_id = function (type_id) {
+  var anchor = this;
 
-    var ret = null;
-    ret = anchor._id2type[type_id];
+  var ret = null;
+  ret = anchor._id2type[type_id];
 
-    return ret;
+  return ret;
 };
 
 /**
@@ -2414,25 +2448,25 @@ noctua_node.prototype.get_type_by_id = function(type_id){
  *
  * @returns {Array} of {class_expression}
  */
-noctua_node.prototype.get_unique_root_types = function(){
-    var anchor = this;
+noctua_node.prototype.get_unique_root_types = function () {
+  var anchor = this;
 
-    var ret = [];
+  var ret = [];
 
-    // Create a checkable representation of the types.
-    var type_cache = {};
-    each(anchor.types(), function(t){
-	type_cache[t.signature()] = true;
-    });
+  // Create a checkable representation of the types.
+  var type_cache = {};
+  each(anchor.types(), function (t) {
+    type_cache[t.signature()] = true;
+  });
 
-    // Do a lookup.
-    each(anchor.root_types(), function(t){
-	if( ! type_cache[t.signature()] ){
-	    ret.push(t);
-	}
-    });
+  // Do a lookup.
+  each(anchor.root_types(), function (t) {
+    if (!type_cache[t.signature()]) {
+      ret.push(t);
+    }
+  });
 
-    return ret;
+  return ret;
 };
 
 /**
@@ -2447,25 +2481,25 @@ noctua_node.prototype.get_unique_root_types = function(){
  *
  * @returns {Array} of {class_expression}
  */
-noctua_node.prototype.get_unique_inferred_types = function(){
-    var anchor = this;
+noctua_node.prototype.get_unique_inferred_types = function () {
+  var anchor = this;
 
-    var ret = [];
+  var ret = [];
 
-    // Create a checkable representation of the types.
-    var type_cache = {};
-    each(anchor.types(), function(t){
-	type_cache[t.signature()] = true;
-    });
+  // Create a checkable representation of the types.
+  var type_cache = {};
+  each(anchor.types(), function (t) {
+    type_cache[t.signature()] = true;
+  });
 
-    // Do a lookup.
-    each(anchor.inferred_types(), function(t){
-	if( ! type_cache[t.signature()] ){
-	    ret.push(t);
-	}
-    });
+  // Do a lookup.
+  each(anchor.inferred_types(), function (t) {
+    if (!type_cache[t.signature()]) {
+      ret.push(t);
+    }
+  });
 
-    return ret;
+  return ret;
 };
 
 /**
@@ -2480,25 +2514,25 @@ noctua_node.prototype.get_unique_inferred_types = function(){
  *
  * @returns {Array} of {class_expression}
  */
-noctua_node.prototype.get_unique_inferred_types_with_all = function(){
-    var anchor = this;
+noctua_node.prototype.get_unique_inferred_types_with_all = function () {
+  var anchor = this;
 
-    var ret = [];
+  var ret = [];
 
-    // Create a checkable representation of the types.
-    var type_cache = {};
-    each(anchor.types(), function(t){
-	type_cache[t.signature()] = true;
-    });
+  // Create a checkable representation of the types.
+  var type_cache = {};
+  each(anchor.types(), function (t) {
+    type_cache[t.signature()] = true;
+  });
 
-    // Do a lookup.
-    each(anchor.inferred_types_with_all(), function(t){
-	if( ! type_cache[t.signature()] ){
-	    ret.push(t);
-	}
-    });
+  // Do a lookup.
+  each(anchor.inferred_types_with_all(), function (t) {
+    if (!type_cache[t.signature()]) {
+      ret.push(t);
+    }
+  });
 
-    return ret;
+  return ret;
 };
 
 /**
@@ -2513,17 +2547,17 @@ noctua_node.prototype.get_unique_inferred_types_with_all = function(){
  * @param {graph|null} [subgraph] - the subgraph to "hide" inside this individual in the graph, or null to reset it
  * @returns {graph|null} contained subgraph
  */
-noctua_node.prototype.subgraph = function(subgraph){
-    if( typeof(subgraph) === 'undefined' ){
-	// Just return current state.
-    }else if( subgraph === null ){
-	// Reset state (and return).
-	this._embedded_subgraph = null;
-    }else if(bbop.what_is(subgraph) === 'bbop-graph-noctua.graph'){
-	// Update state (and return).
-	this._embedded_subgraph = subgraph;
-    }
-    return this._embedded_subgraph;
+noctua_node.prototype.subgraph = function (subgraph) {
+  if (typeof subgraph === "undefined") {
+    // Just return current state.
+  } else if (subgraph === null) {
+    // Reset state (and return).
+    this._embedded_subgraph = null;
+  } else if (bbop.what_is(subgraph) === "bbop-graph-noctua.graph") {
+    // Update state (and return).
+    this._embedded_subgraph = subgraph;
+  }
+  return this._embedded_subgraph;
 };
 
 ///
@@ -2542,16 +2576,16 @@ var bbop_edge = bbop_model.edge;
  * @param {String} [predicate] - preidcate id; if not provided, will use defined default (you probably want to provide one--explicit is better)
  * @returns {this}
  */
-function noctua_edge(subject, object, predicate){
-    bbop_edge.call(this, subject, object, predicate);
-    this._is_a = 'bbop-graph-noctua.edge';
+function noctua_edge(subject, object, predicate) {
+  bbop_edge.call(this, subject, object, predicate);
+  this._is_a = "bbop-graph-noctua.edge";
 
-    // Edges are not completely anonymous in this world.
-    this._id = bbop.uuid();
-    this._predicate_label = null;
+  // Edges are not completely anonymous in this world.
+  this._id = bbop.uuid();
+  this._predicate_label = null;
 
-    this._annotations = [];
-    this._referenced_subgraphs = [];
+  this._annotations = [];
+  this._referenced_subgraphs = [];
 }
 bbop.extend(noctua_edge, bbop_edge);
 
@@ -2560,32 +2594,30 @@ bbop.extend(noctua_edge, bbop_edge);
  *
  * @returns {edge} - new copy of edge
  */
-noctua_edge.prototype.clone = function(){
-    var anchor = this;
+noctua_edge.prototype.clone = function () {
+  var anchor = this;
 
-    // Fresh.
-    var new_clone = new noctua_edge(anchor.subject_id(),
-				    anchor.object_id(),
-				    anchor.predicate_id());
+  // Fresh.
+  var new_clone = new noctua_edge(anchor.subject_id(), anchor.object_id(), anchor.predicate_id());
 
-    // Same id.
-    new_clone._id = anchor._id;
-    new_clone._predicate_label = anchor._predicate_label;
+  // Same id.
+  new_clone._id = anchor._id;
+  new_clone._predicate_label = anchor._predicate_label;
 
-    // Base class stuff.
-    new_clone.default_predicate = anchor.default_predicate;
-    new_clone.type(anchor.type());
-    new_clone.metadata(bbop.clone(anchor.metadata()));
+  // Base class stuff.
+  new_clone.default_predicate = anchor.default_predicate;
+  new_clone.type(anchor.type());
+  new_clone.metadata(bbop.clone(anchor.metadata()));
 
-    // Transfer over the new goodies.
-    each(anchor._annotations, function(annotation){
-	new_clone._annotations.push(annotation.clone());
-    });
-    each(anchor._referenced_subgraphs, function(ind){
-	new_clone._referenced_subgraphs.push(ind.clone());
-    });
+  // Transfer over the new goodies.
+  each(anchor._annotations, function (annotation) {
+    new_clone._annotations.push(annotation.clone());
+  });
+  each(anchor._referenced_subgraphs, function (ind) {
+    new_clone._referenced_subgraphs.push(ind.clone());
+  });
 
-    return new_clone;
+  return new_clone;
 };
 
 /**
@@ -2593,9 +2625,9 @@ noctua_edge.prototype.clone = function(){
  *
  * @returns {String} string
  */
-noctua_edge.prototype.id = function(){
-    return this._id;
- };
+noctua_edge.prototype.id = function () {
+  return this._id;
+};
 
 /**
  * Get/set "source" of edge.
@@ -2604,9 +2636,11 @@ noctua_edge.prototype.id = function(){
  * @param {String} [value] - string
  * @returns {String} string
  */
-noctua_edge.prototype.source = function(value){
-    if(value){ this._subject_id = value; }
-    return this._subject_id;
+noctua_edge.prototype.source = function (value) {
+  if (value) {
+    this._subject_id = value;
+  }
+  return this._subject_id;
 };
 
 /**
@@ -2616,9 +2650,11 @@ noctua_edge.prototype.source = function(value){
  * @param {String} [value] - string
  * @returns {String} string
  */
-noctua_edge.prototype.target = function(value){
-    if(value){ this._object_id = value; }
-    return this._object_id;
+noctua_edge.prototype.target = function (value) {
+  if (value) {
+    this._object_id = value;
+  }
+  return this._object_id;
 };
 
 /**
@@ -2628,9 +2664,11 @@ noctua_edge.prototype.target = function(value){
  * @param {String} [value] - string
  * @returns {String} string
  */
-noctua_edge.prototype.relation = function(value){
-    if(value){ this._predicate_id = value; }
-    return this._predicate_id;
+noctua_edge.prototype.relation = function (value) {
+  if (value) {
+    this._predicate_id = value;
+  }
+  return this._predicate_id;
 };
 
 /**
@@ -2639,38 +2677,31 @@ noctua_edge.prototype.relation = function(value){
  * @param {String} [value] - lbl
  * @returns {String|null} string
  */
-noctua_edge.prototype.label = function(lbl){
-
-    if( lbl === null || typeof(lbl) === 'string' ){
-	this._predicate_label = lbl;
-    }
-    return this._predicate_label;
- };
+noctua_edge.prototype.label = function (lbl) {
+  if (lbl === null || typeof lbl === "string") {
+    this._predicate_label = lbl;
+  }
+  return this._predicate_label;
+};
 
 // Add generic bulk annotation operations to: graph, edge, and node.
-each([noctua_graph, noctua_node, noctua_edge], function(constructr){
-    constructr.prototype.annotations = _annotations;
-    constructr.prototype.add_annotation = _add_annotation;
-    constructr.prototype.get_annotations_by_filter = _get_annotations_by_filter;
-    constructr.prototype.get_annotations_by_key = _get_annotations_by_key;
-    constructr.prototype.get_annotation_by_id = _get_annotation_by_id;
+each([noctua_graph, noctua_node, noctua_edge], function (constructr) {
+  constructr.prototype.annotations = _annotations;
+  constructr.prototype.add_annotation = _add_annotation;
+  constructr.prototype.get_annotations_by_filter = _get_annotations_by_filter;
+  constructr.prototype.get_annotations_by_key = _get_annotations_by_key;
+  constructr.prototype.get_annotation_by_id = _get_annotation_by_id;
 });
 
 // Add generic evidence (referenced individuals) operations to: edge
 // and node.
-each([noctua_node, noctua_edge], function(constructr){
-    constructr.prototype.referenced_subgraphs =
-	_referenced_subgraphs;
-    constructr.prototype.add_referenced_subgraph =
-	_add_referenced_subgraph;
-    constructr.prototype.get_referenced_subgraphs_by_filter =
-	_get_referenced_subgraphs_by_filter;
-    constructr.prototype.get_referenced_subgraph_by_id =
-	_get_referenced_subgraph_by_id;
-    constructr.prototype.get_referenced_subgraph_profiles =
-	_get_referenced_subgraph_profiles;
-    constructr.prototype.get_basic_evidence =
-	_get_basic_evidence;
+each([noctua_node, noctua_edge], function (constructr) {
+  constructr.prototype.referenced_subgraphs = _referenced_subgraphs;
+  constructr.prototype.add_referenced_subgraph = _add_referenced_subgraph;
+  constructr.prototype.get_referenced_subgraphs_by_filter = _get_referenced_subgraphs_by_filter;
+  constructr.prototype.get_referenced_subgraph_by_id = _get_referenced_subgraph_by_id;
+  constructr.prototype.get_referenced_subgraph_profiles = _get_referenced_subgraph_profiles;
+  constructr.prototype.get_basic_evidence = _get_basic_evidence;
 });
 
 ///
@@ -2678,8 +2709,8 @@ each([noctua_node, noctua_edge], function(constructr){
 ///
 
 export default {
-    annotation: annotation,
-    node: noctua_node,
-    edge: noctua_edge,
-    graph: noctua_graph
+  annotation: annotation,
+  node: noctua_node,
+  edge: noctua_edge,
+  graph: noctua_graph,
 };

--- a/packages/bbop-graph-noctua/src/noctua.js
+++ b/packages/bbop-graph-noctua/src/noctua.js
@@ -1,5 +1,5 @@
 /**
- * Purpose: Noctua editing operations ove a bbop-graph base.
+ * Purpose: Noctua editing operations over a bbop-graph base.
  *
  * The base pieces are just subclasses of their analogs in bbop-graph.
  *
@@ -17,7 +17,7 @@
  * Rules:
  *
  * A clique may only be removed from the graph, with its
- * constitutent sub_cliques contained as referenced subgraphs,
+ * constituent sub_cliques contained as referenced subgraphs,
  * when:
  * - all constituent sub_cliques have the "correct" structure
  * - all clique nodes are in at least one sub_clique

--- a/packages/bbop-graph-noctua/src/noctua.test.js
+++ b/packages/bbop-graph-noctua/src/noctua.test.js
@@ -36,8 +36,16 @@ describe("annotation helpers", function () {
     annotation.annotation("1", "2", "3");
     graph.add_annotation(annotation);
 
-    assert.deepEqual(annotation.annotation(), { key: "1", value: "2", "value-type": "3" }, "annotation is updated");
-    assert.equal(graph.get_annotation_by_id(annotation.id()).id(), annotation.id(), "graph lookup works");
+    assert.deepEqual(
+      annotation.annotation(),
+      { key: "1", value: "2", "value-type": "3" },
+      "annotation is updated",
+    );
+    assert.equal(
+      graph.get_annotation_by_id(annotation.id()).id(),
+      annotation.id(),
+      "graph lookup works",
+    );
     assert.equal(graph.get_annotations_by_key("1").length, 1, "graph key lookup works");
   });
 });
@@ -93,7 +101,11 @@ describe("evidence folding", function () {
   it("finds evidence seeds and cliques", function () {
     var graph = loadStandardGraph();
 
-    assert.equal(Object.keys(graph.extract_evidence_seeds()).length, 8, "all seeds are discoverable");
+    assert.equal(
+      Object.keys(graph.extract_evidence_seeds()).length,
+      8,
+      "all seeds are discoverable",
+    );
 
     var clique = graph.get_evidence_clique(seedA);
     var subclique = graph.get_evidence_subclique(seedA);
@@ -165,7 +177,11 @@ describe("graph updates", function () {
     baseForUpdate.update_with(updateGraph);
     assert.equal(baseForUpdate.annotations().length, 1, "update_with replaces graph annotations");
     assert.equal(baseForUpdate.all_nodes().length, 9, "update_with keeps folded duplicate nodes");
-    assert.equal(baseForUpdate.all_edges().length, 4, "update_with replaces local edges for updated nodes");
+    assert.equal(
+      baseForUpdate.all_edges().length,
+      4,
+      "update_with replaces local edges for updated nodes",
+    );
 
     baseForMerge.merge_special(updateGraph);
     assert.equal(baseForMerge.annotations().length, 1, "merge_special replaces graph annotations");
@@ -212,7 +228,11 @@ describe("validation metadata", function () {
     assert.equal(invalidGraph.valid_owl_p(), true, "owl validity loaded");
     assert.equal(invalidGraph.valid_shex_p(), false, "shex validity loaded");
     assert.equal(invalidGraph.violations().length, 2, "violations loaded");
-    assert.equal(invalidGraph.get_violations_by_id("gomodel:5d88482400000052/5d88482400000080").length, 1, "violations are queryable by node id");
+    assert.equal(
+      invalidGraph.get_violations_by_id("gomodel:5d88482400000052/5d88482400000080").length,
+      1,
+      "violations are queryable by node id",
+    );
 
     var inferredNode = invalidGraph.get_node("gomodel:5d88482400000052/5d88482400000053");
     assert.equal(inferredNode.types().length, 1, "base type retained");

--- a/packages/bbop-graph-noctua/src/noctua.test.js
+++ b/packages/bbop-graph-noctua/src/noctua.test.js
@@ -1,0 +1,229 @@
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { assert } from "chai";
+import model from "./noctua.js";
+
+const modelA = "gomodel:5525a0fc00000001";
+const seedA = "obo:#5525a0fc00000001%2F5595c4cb00000425";
+const leafA = "gomodel:5525a0fc00000001/5525a0fc0000023";
+const nodeA = "obo:#5525a0fc00000001%2F5595c4cb00000431";
+
+function loadFixture(name) {
+  return JSON.parse(readFileSync(new URL(`./fixtures/${name}`, import.meta.url), "utf8"));
+}
+
+function loadGraph(name) {
+  var raw = loadFixture(name);
+  var graph = new model.graph();
+  graph.load_data_basic(raw.data);
+  return graph;
+}
+
+function loadStandardGraph() {
+  return loadGraph("minerva-03.json");
+}
+
+describe("annotation helpers", function () {
+  it("store values and are queryable from graph context", function () {
+    var graph = new model.graph();
+    var annotation = new model.annotation({ key: "foo", value: "bar" });
+
+    assert.isString(annotation.id(), "string id");
+    assert.equal(annotation.key(), "foo", "has key");
+    assert.equal(annotation.value(), "bar", "has value");
+    assert.equal(annotation.value_type(), null, "has no value-type");
+
+    annotation.annotation("1", "2", "3");
+    graph.add_annotation(annotation);
+
+    assert.deepEqual(annotation.annotation(), { key: "1", value: "2", "value-type": "3" }, "annotation is updated");
+    assert.equal(graph.get_annotation_by_id(annotation.id()).id(), annotation.id(), "graph lookup works");
+    assert.equal(graph.get_annotations_by_key("1").length, 1, "graph key lookup works");
+  });
+});
+
+describe("minerva loading", function () {
+  it("loads graph metadata, node types, and edge ids", function () {
+    var graph = loadStandardGraph();
+
+    assert.equal(graph.id(), modelA, "graph id");
+    assert.equal(graph.annotations().length, 4, "graph annotations loaded");
+    assert.equal(graph.all_nodes().length, 22, "node count loaded");
+    assert.equal(graph.all_edges().length, 14, "edge count loaded");
+
+    var node = graph.get_node(leafA);
+    assert.equal(node.types().length, 1, "node types loaded");
+    assert.equal(node.types()[0].class_id(), "GO:0005515", "node type id loaded");
+    assert.equal(node.types()[0].class_label(), "protein binding", "node type label loaded");
+
+    var edge = graph.all_edges()[0];
+    assert.equal(graph.get_edge_by_id(edge.id()).id(), edge.id(), "edge ids are tracked");
+  });
+
+  it("loads edge labels from the wire protocol", function () {
+    var graph = loadGraph("minerva-07.json");
+    var edge = graph.all_edges()[0];
+
+    assert.isString(edge.label(), "label is available");
+    assert.notEqual(edge.id(), edge.label(), "edge label is distinct from edge id");
+  });
+});
+
+describe("evidence folding", function () {
+  it("folds evidence into referenced subgraphs and extracts simple evidence", function () {
+    var graph = loadStandardGraph();
+    graph.fold_evidence();
+
+    assert.equal(graph.all_nodes().length, 14, "evidence nodes are folded away");
+
+    var node = graph.get_node(leafA);
+    assert.equal(node.referenced_subgraphs().length, 1, "one referenced subgraph remains");
+
+    var profiles = node.get_referenced_subgraph_profiles();
+    assert.equal(profiles.length, 1, "one evidence profile extracted");
+    assert.equal(profiles[0].class_expressions.length, 1, "profile retains class expression");
+    assert.equal(profiles[0].annotations.length, 1, "profile retains annotation");
+
+    var evidence = node.get_basic_evidence(["source"]);
+    assert.equal(evidence.length, 1, "simple evidence extracted");
+    assert.equal(evidence[0].cls, "physical interaction evidence", "evidence class is readable");
+    assert.equal(evidence[0].source, "PMID:12048186", "evidence source is retained");
+  });
+
+  it("finds evidence seeds and cliques", function () {
+    var graph = loadStandardGraph();
+
+    assert.equal(Object.keys(graph.extract_evidence_seeds()).length, 8, "all seeds are discoverable");
+
+    var clique = graph.get_evidence_clique(seedA);
+    var subclique = graph.get_evidence_subclique(seedA);
+
+    assert.equal(clique.id(), seedA, "clique keeps seed id");
+    assert.equal(clique.all_nodes().length, 1, "simple clique has one node");
+    assert.equal(subclique.id(), seedA, "subclique keeps seed id");
+    assert.equal(subclique.all_nodes().length, 1, "simple subclique has one node");
+  });
+});
+
+describe("noctua folding modes", function () {
+  it("folds and unfolds go-noctua subgraphs including reverse relations", function () {
+    var graph = loadGraph("minerva-05.json");
+    var relations = ["RO:0002333", "BFO:0000066", "RO:0002233", "RO:0002488"];
+    var reverseRelations = ["BFO:0000051"];
+
+    assert.equal(graph.all_nodes().length, 12, "pre-fold node count");
+    assert.equal(graph.all_edges().length, 5, "pre-fold edge count");
+
+    graph.fold_go_noctua(relations, reverseRelations);
+    assert.equal(graph.all_nodes().length, 3, "folded node count");
+    assert.equal(graph.all_edges().length, 1, "folded edge count");
+
+    graph.unfold();
+    assert.equal(graph.all_nodes().length, 12, "unfold restores nodes");
+    assert.equal(graph.all_edges().length, 5, "unfold restores edges");
+  });
+
+  it("survives repeated deep folding and unfolding", function () {
+    var graph = loadGraph("minerva-09.json");
+    var relations = [
+      "RO:0002233",
+      "RO:0002234",
+      "RO:0002333",
+      "RO:0002488",
+      "BFO:0000066",
+      "BFO:0000051",
+      "RO:0000053",
+    ];
+
+    for (var i = 0; i < 100; i++) {
+      assert.equal(graph.all_nodes().length, 8, `nodes before cycle ${i}`);
+      assert.equal(graph.all_edges().length, 7, `edges before cycle ${i}`);
+      graph.fold_go_noctua(relations);
+      graph.unfold();
+      assert.equal(graph.all_nodes().length, 8, `nodes after cycle ${i}`);
+      assert.equal(graph.all_edges().length, 7, `edges after cycle ${i}`);
+    }
+  });
+});
+
+describe("graph updates", function () {
+  it("distinguishes update_with from merge_special in folded graphs", function () {
+    var relations = ["RO:0002333", "BFO:0000066"];
+    var baseForUpdate = loadStandardGraph();
+    var baseForMerge = loadStandardGraph();
+    var updateGraph = new model.graph();
+
+    baseForUpdate.fold_go_noctua(relations);
+    baseForMerge.fold_go_noctua(relations);
+
+    updateGraph.add_annotation(new model.annotation({ key: "title", value: "meow" }));
+    updateGraph.add_node(new model.node(leafA));
+    updateGraph.add_node(new model.node(nodeA));
+    updateGraph.add_node(new model.node("blahblah"));
+    updateGraph.add_edge(new model.edge(leafA, nodeA, "RO:1234567"));
+
+    baseForUpdate.update_with(updateGraph);
+    assert.equal(baseForUpdate.annotations().length, 1, "update_with replaces graph annotations");
+    assert.equal(baseForUpdate.all_nodes().length, 9, "update_with keeps folded duplicate nodes");
+    assert.equal(baseForUpdate.all_edges().length, 4, "update_with replaces local edges for updated nodes");
+
+    baseForMerge.merge_special(updateGraph);
+    assert.equal(baseForMerge.annotations().length, 1, "merge_special replaces graph annotations");
+    assert.equal(baseForMerge.all_nodes().length, 9, "merge_special keeps node counts aligned");
+    assert.equal(baseForMerge.all_edges().length, 8, "merge_special keeps non-overlapping edges");
+  });
+
+  it("merges noctua metadata into an empty graph", function () {
+    var incoming = loadStandardGraph();
+    var graph = new model.graph();
+
+    incoming.fold_evidence();
+    graph.merge_in(incoming);
+
+    assert.equal(graph.all_nodes().length, 14, "merged nodes preserved");
+    assert.equal(graph.all_edges().length, 14, "merged edges preserved");
+    assert.equal(graph.annotations().length, 4, "graph annotations merge in");
+    assert.isString(graph.get_node_elt_id(graph.all_nodes()[0].id()), "node elt ids are created");
+  });
+});
+
+describe("validation metadata", function () {
+  it("tracks inconsistent and modified flags through clone", function () {
+    var raw = loadFixture("minerva-03.json");
+    raw.data["inconsistent-p"] = true;
+    raw.data["modified-p"] = true;
+
+    var graph = new model.graph();
+    graph.load_data_basic(raw.data);
+    var clone = graph.clone();
+
+    assert.equal(graph.inconsistent_p(), true, "inconsistent flag loaded");
+    assert.equal(graph.modified_p(), true, "modified flag loaded");
+    assert.equal(clone.inconsistent_p(), true, "inconsistent flag cloned");
+    assert.equal(clone.modified_p(), true, "modified flag cloned");
+  });
+
+  it("loads validation results, violations, inferred closures, and root types", function () {
+    var invalidGraph = loadGraph("response-gomodel-5d88482400000052-2019-09-25.json");
+    var validGraph = loadGraph("response-gomodel-R-HSA-159740-2019-09-26.json");
+    var rootedGraph = loadGraph("response-gomodel-596ef51500000088-2020-07-01.json");
+
+    assert.equal(invalidGraph.valid_p(), false, "overall validity loaded");
+    assert.equal(invalidGraph.valid_owl_p(), true, "owl validity loaded");
+    assert.equal(invalidGraph.valid_shex_p(), false, "shex validity loaded");
+    assert.equal(invalidGraph.violations().length, 2, "violations loaded");
+    assert.equal(invalidGraph.get_violations_by_id("gomodel:5d88482400000052/5d88482400000080").length, 1, "violations are queryable by node id");
+
+    var inferredNode = invalidGraph.get_node("gomodel:5d88482400000052/5d88482400000053");
+    assert.equal(inferredNode.types().length, 1, "base type retained");
+    assert.equal(inferredNode.inferred_types().length, 0, "direct inferred types retained");
+    assert.equal(inferredNode.inferred_types_with_all().length, 12, "inferred closure retained");
+
+    assert.equal(validGraph.valid_p(), true, "valid graph remains conformant");
+    assert.equal(validGraph.violations().length, 0, "valid graph has no violations");
+
+    var rootedNode = rootedGraph.get_node("gomodel:596ef51500000088/5b91dbd100000466");
+    assert.equal(rootedNode.root_types().length, 3, "root types are loaded when present");
+    assert.equal(rootedNode.get_unique_root_types().length, 3, "root type helper remains usable");
+  });
+});

--- a/packages/bbop-layout/package.json
+++ b/packages/bbop-layout/package.json
@@ -8,9 +8,9 @@
     "Gene Ontology",
     "bbop",
     "client",
+    "cytoscape",
     "graph",
     "layout",
-    "cytoscape",
     "node",
     "npm",
     "server"

--- a/packages/bbop-layout/src/layout.js
+++ b/packages/bbop-layout/src/layout.js
@@ -888,8 +888,7 @@ var cytoscape_layout_engines = function (ngraph, layout, args) {
       group: "nodes",
       data: {
         id: n.id(),
-        degree:
-          ngraph.get_child_nodes(n.id()).length * 10 + ngraph.get_parent_nodes(n.id()).length,
+        degree: ngraph.get_child_nodes(n.id()).length * 10 + ngraph.get_parent_nodes(n.id()).length,
       },
     });
   });

--- a/packages/class-expression/README.md
+++ b/packages/class-expression/README.md
@@ -1,0 +1,11 @@
+# class-expression
+
+## Overview
+
+A handling library for OWL-style class expressions in JavaScript.
+
+### Availability
+
+[GitHub](https://github.com/berkeleybop/bbop-js-monorepo/packages/class-expression)
+
+[NPM](https://www.npmjs.com/package/class-expression)

--- a/packages/class-expression/package.json
+++ b/packages/class-expression/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "class-expression",
+  "version": "0.0.13",
+  "description": "A handling library for OWL-style class expressions in JavaScript.",
+  "keywords": [
+    "Berkeley BOP",
+    "GO",
+    "Gene Ontology",
+    "OWL",
+    "bbop",
+    "class",
+    "client",
+    "expression",
+    "graph",
+    "math",
+    "mathematics",
+    "node",
+    "npm",
+    "server"
+  ],
+  "homepage": "https://berkeleybop.org/",
+  "bugs": {
+    "url": "https://github.com/berkeleybop/bbop-js-monorepo/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "SJC <sjcarbon@lbl.gov>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berkeleybop/bbop-js-monorepo.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/class_expression.mjs",
+      "require": "./dist/class_expression.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown --format esm --format cjs src/class_expression.js",
+    "prepack": "npm run build",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "bbop-core": "^0.0.6",
+    "underscore": "^1.13.8"
+  },
+  "devDependencies": {
+    "chai": "^6.2.2"
+  },
+  "engines": {
+    "node": ">=22 <25"
+  }
+}

--- a/packages/class-expression/src/class_expression.js
+++ b/packages/class-expression/src/class_expression.js
@@ -1,0 +1,718 @@
+/**
+ * Class expressions.
+ *
+ * A handling library for OWL-style class expressions in JavaScript.
+ *
+ * The idea here is to have a generic class expression class that can
+ * be used at all levels of communication an display (instead of the
+ * previous major/minor models).
+ *
+ * This is a full-bodied implementation of all the different aspects
+ * that we need to capture for type class expressions: information
+ * capture from JSON, on-the-fly creations, and display
+ * properties. These used to be separate behaviors, but with the
+ * client taking over more responsibility from Minerva, a more robust
+ * and testable soluton was needed.
+ *
+ * Types can be: class ids and the expressions: SVF, union, and
+ * intersection. Of the latter group, all are nestable.
+ *
+ * Categories is a graphical/UI distinction. They can be: instance_of,
+ * <relation id>, union, and intersection.
+ *
+ * @module class-expression
+ */
+
+import us from "underscore";
+import bbop from "bbop-core";
+
+var each = us.each;
+var keys = us.keys;
+var what_is = bbop.what_is;
+
+/**
+ * Core constructor.
+ *
+ * The argument "in_type" may be:
+ *  - a class id (string)
+ *  - a JSON blob as described from Minerva
+ *  - another <class_expression>
+ *  - null (user will load or interactively create one)
+ *
+ * @constructor
+ * @param {String|Object|class_expression|null} - the raw type description (see above)
+ */
+var class_expression = function (in_type) {
+  this._is_a = "class_expression";
+
+  var anchor = this;
+
+  ///
+  /// Initialize.
+  ///
+
+  // in_type is always a JSON object, trivial catch of attempt to
+  // use just a string as a class identifier.
+  if (in_type) {
+    if (what_is(in_type) === "class_expression") {
+      // Unfold and re-parse (takes some properties of new
+      // host).
+      in_type = in_type.structure();
+    } else if (what_is(in_type) === "object") {
+      // Fine as it is.
+    } else if (what_is(in_type) === "string") {
+      // Convert to a safe representation.
+      in_type = {
+        type: "class",
+        id: in_type,
+        label: in_type,
+      };
+    }
+  }
+
+  // Every single one is a precious snowflake (which is necessary
+  // for managing some of the aspects of the UI for some use cases).
+  this._id = bbop.uuid();
+
+  // Derived property defaults.
+  this._type = null;
+  this._category = "unknown";
+  this._class_id = null;
+  this._class_label = null;
+  this._property_id = null;
+  this._property_label = null;
+  // Recursive elements.
+  this._frame = [];
+
+  //
+  this._raw_type = in_type;
+  if (in_type) {
+    anchor.parse(in_type);
+  }
+};
+
+/**
+ * Get the unique ID of this class expression.
+ *
+ * @returns {String} string
+ */
+class_expression.prototype.id = function () {
+  return this._id;
+};
+
+/**
+ * If the type has a recursive frame.
+ *
+ * @returns {Boolean} true or false
+ */
+class_expression.prototype.nested_p = function () {
+  var retval = false;
+  if (this._frame.length > 0) {
+    retval = true;
+  }
+  return retval;
+};
+
+/**
+ * A cheap way of identifying if two class_expressions are the same.
+ * This essentially returns a string of the main attributes of a type.
+ * It is meant to be semi-unique and collide with dupe inferences.
+ *
+ * BUG/WARNING: At this point, colliding signatures should mean a
+ * dupe, but non-colliding signatures does *not* guarantee that they
+ * are not dupes (think different intersection orderings).
+ *
+ * @returns {String} string
+ */
+class_expression.prototype.signature = function () {
+  var anchor = this;
+
+  var sig = [];
+
+  // The easy ones.
+  sig.push(anchor.category() || "");
+  sig.push(anchor.type() || "");
+  sig.push(anchor.class_id() || "");
+  sig.push(anchor.property_id() || "");
+
+  // And now recursively on frames.
+  if (anchor.frame()) {
+    each(anchor.frame(), function (f) {
+      sig.push(f.signature() || "");
+    });
+  }
+
+  return sig.join("_");
+};
+
+/**
+ * Try to put an instance type into some kind of rendering category.
+ *
+ * @returns {String} string (default 'unknown')
+ */
+class_expression.prototype.category = function () {
+  return this._category;
+};
+
+/**
+ * The "type" of the type.
+ *
+ * @returns {String|null} string or null
+ */
+class_expression.prototype.type = function () {
+  return this._type;
+};
+
+/**
+ * The class expression when we are dealing with SVF.
+ *
+ * @returns {String|null} type or null
+ */
+class_expression.prototype.svf_class_expression = function () {
+  var ret = null;
+  if (this.type() === "svf") {
+    ret = this._frame[0];
+  }
+  return ret;
+};
+
+/**
+ * The class expression when we are dealing with a ComplementOf.
+ *
+ * @returns {String|null} type or null
+ */
+class_expression.prototype.complement_class_expression = function () {
+  var ret = null;
+  if (this.type() === "complement") {
+    ret = this._frame[0];
+  }
+  return ret;
+};
+
+/**
+ * If the type has a recursive frame, a list of the cls expr it
+ * contains.
+ *
+ * @returns {Array} list of {class_expression}
+ */
+class_expression.prototype.frame = function () {
+  return this._frame;
+};
+
+/**
+ * The considered class id.
+ *
+ * @returns {String|null} string or null
+ */
+class_expression.prototype.class_id = function () {
+  return this._class_id;
+};
+
+/**
+ * The considered class label, defaults to ID if not found.
+ *
+ * @returns {String|null} string or null
+ */
+class_expression.prototype.class_label = function () {
+  return this._class_label;
+};
+
+/**
+ * The considered class property id.
+ * Not defined for 'class' types.
+ *
+ * @returns {String|null} string or null
+ */
+class_expression.prototype.property_id = function () {
+  return this._property_id;
+};
+
+/**
+ * The considered class property label.
+ * Not defined for 'class' types.
+ *
+ * @returns {String|null} string or null
+ */
+class_expression.prototype.property_label = function () {
+  return this._property_label;
+};
+
+/**
+ * Parse a JSON blob into the current instance, clobbering anything in
+ * there, except id.
+ *
+ * @params {Object} in_type - conformant JSON object
+ * @returns {this} self
+ */
+class_expression.prototype.parse = function (in_type) {
+  var anchor = this;
+
+  // Helper.
+  function _decide_type(type) {
+    var rettype = null;
+
+    // Easiest case.
+    var t = type["type"] || null;
+    if (t === "class") {
+      rettype = "class";
+    } else if (t === "union") {
+      rettype = "union";
+    } else if (t === "intersection") {
+      rettype = "intersection";
+    } else if (t === "svf") {
+      rettype = "svf";
+    } else if (t === "complement") {
+      rettype = "complement";
+    } else {
+      // No idea...
+    }
+
+    return rettype;
+  }
+
+  // Define the category, and build up an instant picture of what we
+  // need to know about the property.
+  var t = _decide_type(in_type);
+  if (t === "class") {
+    // Easiest to extract.
+    this._type = t;
+    this._category = "instance_of";
+    this._class_id = in_type["id"];
+    this._class_label = in_type["label"] || this._class_id;
+    // No related properties.
+  } else if (t === "union" || t === "intersection") {
+    // conjunctions
+
+    // These are simply recursive.
+    this._type = t;
+    this._category = t;
+
+    // Load stuff into the frame.
+    this._frame = [];
+    var f_set = in_type["expressions"] || [];
+    each(f_set, function (f_type) {
+      anchor._frame.push(new class_expression(f_type));
+    });
+  } else if (t === "svf") {
+    // SVF
+
+    // We're then dealing with an SVF: a property plus a class
+    // expression. We are expecting a "restriction", although we
+    // don't really do anything with that information (maybe
+    // later).
+    this._type = t;
+    // Extract the property information
+    this._category = in_type["property"]["id"];
+    this._property_id = in_type["property"]["id"];
+    this._property_label = in_type["property"]["label"] || this._property_id;
+
+    // Okay, let's recur down the class expression. It should just
+    // be one, but we'll just reuse the frame. Access should be
+    // though svf_class_expression().
+    var f_type = in_type["filler"];
+    this._frame = [new class_expression(f_type)];
+  } else if (t === "complement") {
+    // ComplementOf
+
+    // We're then dealing with a ComplementOf. Not too bad.
+    this._type = t;
+    this._category = t;
+
+    // Okay, let's recur down the class expression. It should just
+    // be one, but we'll just reuse the frame. Access should be
+    // though complement_class_expression().
+    var f2_type = in_type["filler"];
+    this._frame = [new class_expression(f2_type)];
+  } else {
+    // Should not be possible, so let's stop it here.
+    //console.log('unknown type :', in_type);
+    throw new Error("unknown type leaked in");
+  }
+
+  return anchor;
+};
+
+/**
+ * Parse a JSON blob into the current instance, clobbering anything in
+ * there, except id.
+ *
+ * @params {String} in_type - string
+ * @returns {this} self
+ */
+class_expression.prototype.as_class = function (in_type) {
+  if (in_type) {
+    var ce = new class_expression(in_type);
+    this.parse(ce.structure());
+  }
+
+  return this;
+};
+
+/**
+ * Convert a null class_expression into an arbitrary SVF.
+ *
+ * @params {String} property_id - string
+ * @params {String|class_expression} class_expr - ID string (e.g. GO:0022008) or <class_expression>
+ * @returns {this} self
+ */
+class_expression.prototype.as_svf = function (property_id, class_expr) {
+  // Cheap our way into this--can be almost anything.
+  var cxpr = new class_expression(class_expr);
+
+  // Our list of values must be defined if we go this way.
+  var expression = {
+    type: "svf",
+    property: {
+      type: "property",
+      id: property_id,
+    },
+    filler: cxpr.structure(),
+  };
+
+  this.parse(expression);
+
+  return this;
+};
+
+/**
+ * Convert a null class_expression into an arbitrary complement.
+ *
+ * @params {String|class_expression} class_expr - ID string (e.g. GO:0022008) or <class_expression>
+ * @returns {this} self
+ */
+class_expression.prototype.as_complement = function (class_expr) {
+  // Cheap our way into this--can be almost anything.
+  var cxpr = new class_expression(class_expr);
+
+  // Our list of values must be defined if we go this way.
+  var expression = {
+    type: "complement",
+    filler: cxpr.structure(),
+  };
+
+  this.parse(expression);
+
+  return this;
+};
+
+/**
+ * Convert a null class_expression into a set of class expressions.
+ *
+ * @params {String} set_type - 'intersection' || 'union'
+ * @params {Array} set_list - list of ID strings of <class_expressions>
+ * @returns {this} self
+ */
+class_expression.prototype.as_set = function (set_type, set_list) {
+  // We do allow empties.
+  if (!set_list) {
+    set_list = [];
+  }
+
+  if (set_type === "union" || set_type === "intersection") {
+    // Work into a viable argument.
+    var set = [];
+    each(set_list, function (item) {
+      var cexpr = new class_expression(item);
+      set.push(cexpr.structure());
+    });
+
+    // A little massaging is necessary to get it into the correct
+    // format here.
+    var fset = set_type;
+    var parsable = {};
+    parsable["type"] = fset;
+    parsable["expressions"] = set;
+    this.parse(parsable);
+  }
+
+  return this;
+};
+
+/**
+ * Hm. Essentially dump out the information contained within into a
+ * JSON object that is appropriate for consumption my Minerva
+ * requests.
+ *
+ * @returns {Object} JSON object
+ */
+class_expression.prototype.structure = function () {
+  var anchor = this;
+
+  // We'll return this.
+  var expression = {};
+
+  // Extract type.
+  var t = anchor.type();
+  if (t === "class") {
+    // trivial
+
+    expression["type"] = "class";
+    expression["id"] = anchor.class_id();
+    // Only add label if it adds something?
+    if (anchor.class_label() && anchor.class_id() !== anchor.class_label()) {
+      expression["label"] = anchor.class_label();
+    }
+  } else if (t === "svf") {
+    // SVF
+
+    // Easy part of SVF.
+    expression["type"] = "svf";
+    expression["property"] = {
+      type: "property",
+      id: anchor.property_id(),
+    };
+
+    // Recur for someValuesFrom class expression.
+    var svfce = anchor.svf_class_expression();
+    var st = svfce.type();
+    expression["filler"] = svfce.structure();
+  } else if (t === "complement") {
+    // ComplementOf
+
+    expression["type"] = "complement";
+
+    // Recur for someValuesFrom class expression.
+    var cce = anchor.complement_class_expression();
+    var ct = cce.type();
+    expression["filler"] = cce.structure();
+  } else if (t === "union" || t === "intersection") {
+    // compositions
+
+    // Recursively add all of the types in the frame.
+    var ecache = [];
+    var frame = anchor.frame();
+    each(frame, function (ftype) {
+      ecache.push(ftype.structure());
+    });
+
+    // Correct structure.
+    expression["type"] = t;
+    expression["expressions"] = ecache;
+  } else {
+    throw new Error("unknown type in request processing: " + t);
+  }
+
+  return expression;
+};
+
+/**
+ * An attempt to have a simple attempt at a string representation for
+ * a class expression.
+ *
+ * @param {String} front_str - (optional) start the output string with (default '')
+ * @param {String} back_str - (optional) end the output string with (default '')
+ * @returns {String} simple string rep
+ */
+class_expression.prototype.to_string = function (front_str, back_str) {
+  var anchor = this;
+
+  function _inner_lbl(ce) {
+    var inner_lbl = "???";
+
+    var cetype = ce.type();
+    if (cetype === "class") {
+      inner_lbl = ce.class_label();
+    } else if (cetype === "union" || cetype === "intersection") {
+      var cef = ce.frame();
+      inner_lbl = cetype + "[" + cef.length + "]";
+    } else if (cetype === "complement") {
+      inner_lbl = "[NOT]";
+    } else if (cetype === "svf") {
+      inner_lbl = "[SVF]";
+    } else {
+      inner_lbl = "???";
+    }
+
+    return inner_lbl;
+  }
+
+  var ret = "[???]";
+
+  var t = anchor.type();
+  var f = anchor.frame();
+
+  if (t === "class") {
+    ret = anchor.class_label();
+  } else if (t === "union" || t === "intersection") {
+    ret = t + "[" + f.length + "]";
+  } else if (t === "complement") {
+    ret =
+      "NOT" +
+      //'[' + anchor.to_string(anchor.complement_class_expression()) + ']';
+      "[" +
+      _inner_lbl(anchor.complement_class_expression()) +
+      "]";
+  } else if (t === "svf") {
+    // SVF a little harder.
+    var ctype = anchor.property_label();
+
+    // Probe it a bit.
+    var ce = anchor.svf_class_expression();
+    ret = "svf[" + ctype + "](" + _inner_lbl(ce) + ")";
+  } else {
+    ret = "???";
+  }
+
+  // A little special "hi" for inferred types, or something.
+  if (front_str && typeof front_str === "string") {
+    ret = front_str + ret;
+  }
+  if (back_str && typeof back_str === "string") {
+    ret = ret + back_str;
+  }
+
+  return ret;
+};
+
+/**
+ * An attempt to have a simple attempt at a string representation for
+ * a class expression, with some extra information possibly not found
+ * in the to_String() version (like maybe a visible ID, etc.).
+ *
+ * @param {String} front_str - (optional) start the output string with (default '')
+ * @param {String} back_str - (optional) end the output string with (default '')
+ * @returns {String} simple string rep
+ */
+class_expression.prototype.to_string_plus = function (front_str, back_str) {
+  var anchor = this;
+
+  // Class label is main, but prepend class ID if available and
+  // different.
+  function _class_labeler(ce) {
+    var ret = ce.class_label();
+    // Optional ID.
+    var cid = ce.class_id();
+    if (cid && cid !== ret) {
+      ret = "[" + cid + "] " + ret;
+    }
+    return ret;
+  }
+
+  function _inner_lbl(ce) {
+    var inner_lbl = "???";
+
+    var cetype = ce.type();
+    if (cetype === "class") {
+      inner_lbl = _class_labeler(ce);
+    } else if (cetype === "union" || cetype === "intersection") {
+      var cef = ce.frame();
+      inner_lbl = cetype + "[" + cef.length + "]";
+    } else if (cetype === "complement") {
+      inner_lbl = "[NOT]";
+    } else if (cetype === "svf") {
+      inner_lbl = "[SVF]";
+    } else {
+      inner_lbl = "???";
+    }
+
+    return inner_lbl;
+  }
+
+  var ret = "[???]";
+
+  var t = anchor.type();
+  var f = anchor.frame();
+
+  if (t === "class") {
+    ret = _class_labeler(anchor);
+  } else if (t === "union" || t === "intersection") {
+    ret = t + "[" + f.length + "]";
+  } else if (t === "complement") {
+    ret =
+      "NOT" +
+      //'[' + anchor.to_string(anchor.complement_class_expression()) + ']';
+      "[" +
+      _inner_lbl(anchor.complement_class_expression()) +
+      "]";
+  } else if (t === "svf") {
+    // SVF a little harder.
+    var ctype = anchor.property_label();
+
+    // Probe it a bit.
+    var ce = anchor.svf_class_expression();
+    ret = "svf[" + ctype + "](" + _inner_lbl(ce) + ")";
+  } else {
+    ret = "???";
+  }
+
+  // A little special "hi" for inferred types, or something.
+  if (front_str && typeof front_str === "string") {
+    ret = front_str + ret;
+  }
+  if (back_str && typeof back_str === "string") {
+    ret = ret + back_str;
+  }
+
+  return ret;
+};
+
+///
+/// "Static" functions in package.
+///
+
+/**
+ * "Static" function that creates an intersection from a list of
+ * whatever.
+ *
+ * @param {Array} list - list of conformant whatever
+ * @returns {class_expression} object
+ */
+class_expression.intersection = function (list) {
+  var ce = new class_expression();
+  ce.as_set("intersection", list);
+  return ce;
+};
+
+/**
+ * "Static" function that creates a union from a list of whatever.
+ *
+ * @param {Array} list - list of conformant whatever
+ * @returns {class_expression} object
+ */
+class_expression.union = function (list) {
+  var ce = new class_expression();
+  ce.as_set("union", list);
+  return ce;
+};
+
+/**
+ * "Static" function that creates a SomeValueFrom from a property ID
+ * and a class_expression (or string or whatever).
+ *
+ * @param {String} prop_id - ID
+ * @param {class_expression|String} cls_expr - thing
+ * @returns {class_expression} object
+ */
+class_expression.svf = function (prop_id, cls_expr) {
+  var ce = new class_expression();
+  ce.as_svf(prop_id, cls_expr);
+  return ce;
+};
+
+/**
+ * "Static" function that creates the complement of a given class
+ * expression.
+ *
+ * @param {class_expression|String} cls_expr - thing
+ * @returns {class_expression} object
+ */
+class_expression.complement = function (cls_expr) {
+  var ce = new class_expression();
+  ce.as_complement(cls_expr);
+  return ce;
+};
+
+/**
+ * "Static" function that creates a class_expression from a class ID.
+ *
+ * @param {String} id - string id
+ * @returns {class_expression} object
+ */
+class_expression.cls = function (id) {
+  var ce = new class_expression();
+  ce.as_class(id);
+  return ce;
+};
+
+// Exportable body.
+export default class_expression;

--- a/packages/class-expression/src/class_expression.js
+++ b/packages/class-expression/src/class_expression.js
@@ -12,7 +12,7 @@
  * capture from JSON, on-the-fly creations, and display
  * properties. These used to be separate behaviors, but with the
  * client taking over more responsibility from Minerva, a more robust
- * and testable soluton was needed.
+ * and testable solution was needed.
  *
  * Types can be: class ids and the expressions: SVF, union, and
  * intersection. Of the latter group, all are nestable.

--- a/packages/class-expression/src/class_expression.test.js
+++ b/packages/class-expression/src/class_expression.test.js
@@ -1,0 +1,217 @@
+import { describe, it } from "node:test";
+import { assert } from "chai";
+import ClassExpression from "./class_expression.js";
+
+describe("basic operations", function () {
+  it("probes an empty expression", function () {
+    var expression = new ClassExpression();
+
+    assert.equal(expression.id().length, 36, "uuid-shaped id");
+    assert.isFalse(expression.nested_p(), "not nested");
+    assert.equal(expression.category(), "unknown", "unknown category");
+    assert.isNull(expression.type(), "unknown type");
+    assert.isNull(expression.class_id(), "no class id");
+    assert.isNull(expression.class_label(), "no class label");
+    assert.isNull(expression.svf_class_expression(), "no svf");
+    assert.isNull(expression.complement_class_expression(), "no complement");
+    assert.isNull(expression.property_id(), "no property id");
+    assert.isNull(expression.property_label(), "no property label");
+    assert.throws(
+      () => expression.structure(),
+      /unknown type in request processing: null/,
+      "untyped expression cannot be serialized",
+    );
+  });
+
+  it("supports string, object, and copy constructors", function () {
+    var expressions = [
+      new ClassExpression("GO:123"),
+      new ClassExpression({ type: "class", id: "GO:123" }),
+      new ClassExpression(new ClassExpression("GO:123")),
+    ];
+
+    expressions.forEach(function (expression, index) {
+      assert.equal(expression.id().length, 36, `[${index}] uuid-shaped id`);
+      assert.isFalse(expression.nested_p(), `[${index}] not nested`);
+      assert.equal(expression.category(), "instance_of", `[${index}] class category`);
+      assert.equal(expression.type(), "class", `[${index}] class type`);
+      assert.equal(expression.class_id(), "GO:123", `[${index}] class id`);
+      assert.equal(expression.class_label(), "GO:123", `[${index}] class label`);
+      assert.isNull(expression.svf_class_expression(), `[${index}] no svf`);
+      assert.isNull(expression.property_id(), `[${index}] no property id`);
+      assert.isNull(expression.property_label(), `[${index}] no property label`);
+      assert.deepEqual(
+        expression.structure(),
+        { type: "class", id: "GO:123" },
+        `[${index}] structure`,
+      );
+    });
+  });
+});
+
+describe("expression builders", function () {
+  it("creates svf expressions after construction", function () {
+    var expression = new ClassExpression(null);
+    expression.as_svf("RO:456", "GO:123");
+
+    assert.isTrue(expression.nested_p(), "svf is nested");
+    assert.equal(expression.category(), "RO:456", "svf category uses property id");
+    assert.equal(expression.type(), "svf", "svf type");
+    assert.isNull(expression.class_id(), "svf has no direct class id");
+    assert.equal(expression.property_id(), "RO:456", "property id");
+    assert.equal(expression.property_label(), "RO:456", "property label falls back to id");
+    assert.deepEqual(
+      expression.svf_class_expression().structure(),
+      { type: "class", id: "GO:123" },
+      "filler structure",
+    );
+    assert.deepEqual(
+      expression.structure(),
+      {
+        type: "svf",
+        property: {
+          type: "property",
+          id: "RO:456",
+        },
+        filler: {
+          type: "class",
+          id: "GO:123",
+        },
+      },
+      "svf structure",
+    );
+  });
+
+  it("creates intersections and nests them inside svfs", function () {
+    var intersection = new ClassExpression();
+    intersection.as_set("intersection", ["GO:123", new ClassExpression("GO:456")]);
+
+    assert.isTrue(intersection.nested_p(), "intersection is nested");
+    assert.equal(intersection.category(), "intersection", "intersection category");
+    assert.equal(intersection.type(), "intersection", "intersection type");
+    assert.deepEqual(
+      intersection.structure(),
+      {
+        type: "intersection",
+        expressions: [
+          { type: "class", id: "GO:123" },
+          { type: "class", id: "GO:456" },
+        ],
+      },
+      "intersection structure",
+    );
+
+    var nested = new ClassExpression();
+    nested.as_svf("RO:123", intersection);
+
+    assert.equal(nested.svf_class_expression().type(), "intersection", "nested filler type");
+    assert.equal(nested.property_id(), "RO:123", "nested property id");
+    assert.deepEqual(
+      nested.structure(),
+      {
+        type: "svf",
+        property: {
+          type: "property",
+          id: "RO:123",
+        },
+        filler: {
+          type: "intersection",
+          expressions: [
+            { type: "class", id: "GO:123" },
+            { type: "class", id: "GO:456" },
+          ],
+        },
+      },
+      "nested svf structure",
+    );
+  });
+
+  it("creates complements", function () {
+    var intersection = new ClassExpression();
+    intersection.as_set("intersection", ["GO:123", "GO:456"]);
+    var expression = new ClassExpression();
+    expression.as_complement(intersection);
+
+    assert.isTrue(expression.nested_p(), "complement is nested");
+    assert.equal(expression.category(), "complement", "complement category");
+    assert.equal(expression.type(), "complement", "complement type");
+    assert.equal(
+      expression.complement_class_expression().type(),
+      "intersection",
+      "complement filler type",
+    );
+    assert.deepEqual(
+      expression.structure(),
+      {
+        type: "complement",
+        filler: {
+          type: "intersection",
+          expressions: [
+            { type: "class", id: "GO:123" },
+            { type: "class", id: "GO:456" },
+          ],
+        },
+      },
+      "complement structure",
+    );
+  });
+});
+
+describe("string writers", function () {
+  it("renders compact strings for nested expressions", function () {
+    var intersection = new ClassExpression();
+    intersection.as_set("intersection", ["GO:123", "GO:456"]);
+
+    var complement = new ClassExpression();
+    complement.as_complement(intersection);
+    assert.equal(complement.to_string(), "NOT[intersection[2]]", "complement string form");
+
+    var svf = new ClassExpression();
+    svf.as_svf("RO:123", intersection);
+    assert.equal(svf.to_string(), "svf[RO:123](intersection[2])", "svf string form");
+  });
+
+  it("renders labeled strings and string-plus output", function () {
+    var plain = new ClassExpression("GO:0022008");
+    assert.equal(plain.to_string(), "GO:0022008", "plain string form");
+    assert.equal(plain.to_string_plus(), "GO:0022008", "plain string-plus form");
+
+    var labeled = new ClassExpression({
+      type: "class",
+      id: "GO:0022008",
+      label: "neurogenesis",
+    });
+    assert.equal(labeled.to_string(), "neurogenesis", "labeled string form");
+    assert.equal(labeled.to_string_plus(), "[GO:0022008] neurogenesis", "labeled string-plus form");
+  });
+});
+
+describe("static builders", function () {
+  it("creates classes, unions, svfs, and complements", function () {
+    var cls = ClassExpression.cls("GO:123");
+    assert.equal(cls.type(), "class", "static class builder");
+
+    var union = ClassExpression.union(["GO:123", "GO:456"]);
+    assert.equal(union.type(), "union", "static union builder");
+    assert.equal(union.frame().length, 2, "union frame size");
+
+    var svf = ClassExpression.svf("RO:789", "GO:123");
+    assert.equal(svf.type(), "svf", "static svf builder");
+    assert.equal(svf.property_id(), "RO:789", "static svf property id");
+
+    var complement = ClassExpression.complement("GO:123");
+    assert.equal(complement.type(), "complement", "static complement builder");
+    assert.equal(
+      complement.complement_class_expression().class_id(),
+      "GO:123",
+      "static complement filler",
+    );
+  });
+
+  it("produces stable signatures for identical structures", function () {
+    var left = ClassExpression.svf("RO:123", ClassExpression.intersection(["GO:123", "GO:456"]));
+    var right = new ClassExpression(left);
+
+    assert.equal(left.signature(), right.signature(), "copied structures share signatures");
+  });
+});


### PR DESCRIPTION
Fixes #8 

These changes add the source of `bbop-graph-noctua` as a new package. This package depends on `class-expression` which is also a package in the BBOP ecosystem. Since `class-expression` depends on `bbop-core` and `bbop-graph-noctua` depends on `class-expression`, I felt it made sense to bring `class-expression` into the monorepo as well.

These changes also apply formatting to a few files that were missed previously. 