### PR TITLE
Add `bbop-rest-manager` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3215,6 +3215,10 @@
       "resolved": "packages/bbop-response-golr",
       "link": true
     },
+    "node_modules/bbop-rest-manager": {
+      "resolved": "packages/bbop-rest-manager",
+      "link": true
+    },
     "node_modules/bbop-rest-response": {
       "resolved": "packages/bbop-rest-response",
       "link": true
@@ -3328,6 +3332,31 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha512-YRc9zvVz4wNaxcXmiSgb9LAg7YYwqQ2xd0Sj6osfA7k/PKmIGVlnOYs3wOFdkRC9/JpQu8sGt/zHgJV7xzerfg=="
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -3379,6 +3408,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cac": {
@@ -3464,6 +3503,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsite": {
@@ -3796,6 +3852,30 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
@@ -3927,6 +4007,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/core-util-is": {
@@ -4153,6 +4243,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -4238,6 +4338,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ejs": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
@@ -4266,6 +4373,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/encoding": {
@@ -4496,6 +4613,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -4514,6 +4638,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/eventemitter3": {
@@ -4554,6 +4688,101 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4586,6 +4815,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -4678,6 +4929,26 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -5222,6 +5493,27 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5505,6 +5797,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5635,6 +5937,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-ssh": {
       "version": "1.4.1",
@@ -6169,6 +6478,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/meow": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
@@ -6300,6 +6619,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -7144,6 +7476,19 @@
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha512-S0sN3agnVh2SZNEIGc0N1X4Z5K0JeFbGBrnuZpsxuUh5XLF0BnvWkMjRXo/zGKLd/eghvNIKcx1pQkmUjXIyrA=="
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -7154,6 +7499,19 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -7737,6 +8095,16 @@
         "better-assert": "~1.0.0"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7779,6 +8147,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -7977,6 +8356,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -7985,6 +8378,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/quansync": {
@@ -8012,6 +8421,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/react-is": {
@@ -8454,6 +8889,23 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-async": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
@@ -8515,6 +8967,87 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -8536,6 +9069,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -8841,6 +9450,16 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -9085,6 +9704,16 @@
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha512-LhVdShQD/4Mk4zXNroIQZJC+Ap3zgLcDuwEdcmLv9CCO73NWockQDwyUnW/m8VX/EElfL6FcYx7EeutN4HJA6A=="
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -9268,6 +9897,48 @@
         "node": ">=8"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -9356,6 +10027,16 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrun": {
       "version": "0.2.37",
       "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.37.tgz",
@@ -9420,6 +10101,16 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/walk-up-path": {
@@ -9753,6 +10444,24 @@
       },
       "devDependencies": {
         "chai": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=22 <25"
+      }
+    },
+    "packages/bbop-rest-manager": {
+      "version": "0.0.17",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bbop-core": "^0.0.6",
+        "bbop-registry": "^0.0.3",
+        "underscore": "^1.13.8"
+      },
+      "devDependencies": {
+        "bbop-rest-response": "^0.0.4",
+        "body-parser": "^2.2.2",
+        "chai": "^6.2.2",
+        "express": "^5.2.1"
       },
       "engines": {
         "node": ">=22 <25"

--- a/packages/bbop-rest-manager/README.md
+++ b/packages/bbop-rest-manager/README.md
@@ -1,0 +1,41 @@
+# bbop-rest-manager
+
+## Overview
+
+The purpose of the bbop-rest-manager is simple: to create an
+easy-to-use JavaScript abstraction for getting external data, usually
+from REST resource, that allows code reuse across client, server, and
+different response systems (promises and function callbacks).
+
+All it needs to function is a RESTful resource to contact and a
+compliant response class (see
+superclass
+[bbop-rest-response](https://github.com/berkeleybop/bbop-js-monorepo/tree/main/packages/bbop-rest-response)). With
+this and a single change in a single line in your code, you can run it
+on the server in Node, on a web client, or as a script.
+
+The current implementation uses the Fetch API for network requests in
+all supported environments.
+
+The primary API is `start()`, which returns a standard Promise and
+also triggers the registered success or error callbacks.
+
+Compatibility aliases for the legacy `node`, `jquery`, and
+`sync_request` managers are still exported, but they now share the
+same asynchronous Fetch-based implementation.
+
+`sync_request` is deprecated and no longer performs synchronous
+requests.
+
+The legacy JSONP configuration methods are still present on the
+`jquery` compatibility manager for API compatibility, but they are now
+no-ops and emit deprecation warnings.
+
+For solid examples of what this does, please see
+the unit tests.
+
+## Availability
+
+[GitHub](https://github.com/berkeleybop/bbop-js-monorepo/tree/main/packages/bbop-rest-manager)
+
+[NPM](https://www.npmjs.com/package/bbop-rest-manager)

--- a/packages/bbop-rest-manager/package.json
+++ b/packages/bbop-rest-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bbop-rest-manager",
   "version": "0.0.17",
-  "description": "The is the 'new' version of the manager event model for BBOP systems.",
+  "description": "This is the 'new' version of the manager event model for BBOP systems.",
   "keywords": [
     "AmiGO",
     "Berkeley BOP",

--- a/packages/bbop-rest-manager/package.json
+++ b/packages/bbop-rest-manager/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "bbop-rest-manager",
+  "version": "0.0.17",
+  "description": "The is the 'new' version of the manager event model for BBOP systems.",
+  "keywords": [
+    "AmiGO",
+    "Berkeley BOP",
+    "GO",
+    "Gene Ontology",
+    "Minerva",
+    "Noctua",
+    "bbop",
+    "client",
+    "node",
+    "npm",
+    "server"
+  ],
+  "homepage": "https://berkeleybop.org/",
+  "bugs": {
+    "url": "https://github.com/berkeleybop/bbop-js-monorepo/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "SJC <sjcarbon@lbl.gov>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berkeleybop/bbop-js-monorepo.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/manager.mjs",
+      "require": "./dist/manager.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown --format esm --format cjs src/manager.js",
+    "prepack": "npm run build",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "bbop-core": "^0.0.6",
+    "bbop-registry": "^0.0.3",
+    "underscore": "^1.13.8"
+  },
+  "devDependencies": {
+    "bbop-rest-response": "^0.0.4",
+    "body-parser": "^2.2.2",
+    "chai": "^6.2.2",
+    "express": "^5.2.1"
+  },
+  "engines": {
+    "node": ">=22 <25"
+  }
+}

--- a/packages/bbop-rest-manager/src/manager.js
+++ b/packages/bbop-rest-manager/src/manager.js
@@ -1,0 +1,367 @@
+/**
+ * Generic BBOP manager for dealing with basic generic REST calls.
+ * This specific one is designed to be overridden by its subclasses.
+ * This one pretty much just uses its incoming resource string as the data.
+ * Mostly for testing purposes.
+ *
+ * Both a <bbop-rest-response> (or clean error data) and the manager
+ * itself (this as anchor) should be passed to the callbacks.
+ *
+ * @module bbop-rest-manager
+ */
+
+import bbop from "bbop-core";
+import us from "underscore";
+import registry from "bbop-registry";
+
+function warnDeprecated(message) {
+  console.warn(message);
+}
+
+function normalizeHeaders(headerPairs) {
+  return Object.fromEntries(headerPairs || []);
+}
+
+function methodWithDefault(method) {
+  if (!method) {
+    return "GET";
+  }
+  return method.toUpperCase();
+}
+
+function buildUrl(resource, payload, method) {
+  if (method !== "GET" || us.isEmpty(payload)) {
+    return resource;
+  }
+
+  var url = new URL(resource);
+  var params = new URLSearchParams(url.search);
+  Object.entries(payload).forEach(function ([key, value]) {
+    if (Array.isArray(value)) {
+      value.forEach(function (item) {
+        params.append(key, item);
+      });
+    } else if (typeof value !== "undefined" && value !== null) {
+      params.append(key, value);
+    }
+  });
+  url.search = params.toString();
+  return url.toString();
+}
+
+function buildRequestInit(payload, method, headers) {
+  var requestHeaders = normalizeHeaders(headers);
+  var init = {
+    method: method,
+    headers: requestHeaders,
+  };
+
+  if (method === "GET") {
+    return init;
+  }
+
+  if (!us.isEmpty(payload)) {
+    var body = new URLSearchParams();
+    Object.entries(payload).forEach(function ([key, value]) {
+      if (Array.isArray(value)) {
+        value.forEach(function (item) {
+          body.append(key, item);
+        });
+      } else if (typeof value !== "undefined" && value !== null) {
+        body.append(key, value);
+      }
+    });
+    if (
+      !Object.keys(requestHeaders).some(function (header) {
+        return header.toLowerCase() === "content-type";
+      })
+    ) {
+      requestHeaders["Content-Type"] = "application/x-www-form-urlencoded;charset=UTF-8";
+    }
+    init.body = body;
+  }
+
+  return init;
+}
+
+function normalizeErrorMessage(error) {
+  if (!error) {
+    return "unknown fetch error";
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+/**
+ * Contructor for the REST manager.
+ *
+ * See also: module:bbop-registry
+ *
+ * @constructor
+ * @param {Object} response_handler - the response handler class to use for each call
+ * @returns {Object} rest manager object
+ */
+function manager_base(response_handler) {
+  registry.call(this, ["success", "error"]);
+  this._is_a = "bbop-rest-manager.base";
+
+  var anchor = this;
+
+  this._logger = new bbop.logger(this._is_a);
+  this._logger.DEBUG = false;
+  function ll(str) {
+    anchor._logger.kvetch(str);
+  }
+
+  this._response_handler = response_handler;
+  this._qurl = null;
+  this._qpayload = {};
+  this._qmethod = "GET";
+  this._headers = [];
+  this._safety = false;
+
+  this.debug = function (p) {
+    if (p === true || p === false) {
+      this._logger.DEBUG = p;
+    }
+    return this._logger.DEBUG;
+  };
+
+  this._ensure_arguments = function (url, payload, method, headers) {
+    ll("ensure arguments...");
+
+    if (typeof url !== "undefined") {
+      this.resource(url);
+    }
+    if (typeof payload !== "undefined") {
+      this.payload(payload);
+    }
+    if (typeof method !== "undefined") {
+      this.method(method);
+    }
+    if (typeof headers !== "undefined") {
+      this.headers(headers);
+    }
+
+    if (!this.resource()) {
+      throw new Error("must have resource defined");
+    }
+  };
+
+  this._apply_callbacks_by_response = function (response) {
+    ll("apply callbacks by response...");
+
+    if (response && response.okay()) {
+      anchor.apply_callbacks("success", [response, anchor]);
+    } else {
+      anchor.apply_callbacks("error", [response, anchor]);
+    }
+  };
+
+  this.resource = function (in_url) {
+    ll("resource called with: " + in_url);
+
+    if (typeof in_url !== "undefined" && bbop.what_is(in_url) === "string") {
+      anchor._qurl = in_url;
+    }
+    return anchor._qurl;
+  };
+
+  this.payload = function (payload) {
+    ll("payload called with: " + payload);
+
+    if (bbop.is_defined(payload) && bbop.what_is(payload) === "object") {
+      anchor._qpayload = payload;
+    }
+    return bbop.clone(anchor._qpayload);
+  };
+
+  this.method = function (method) {
+    ll("method called with: " + method);
+
+    if (bbop.is_defined(method) && bbop.what_is(method) === "string") {
+      anchor._qmethod = methodWithDefault(method);
+    }
+    return anchor._qmethod;
+  };
+
+  this.headers = function (in_headers) {
+    ll("headers called with: " + in_headers);
+
+    if (in_headers && us.isArray(in_headers)) {
+      anchor._headers = in_headers;
+    }
+    return anchor._headers;
+  };
+
+  this.run_promise_functions = async function (
+    promise_function_stack,
+    accumulator_function,
+    final_function,
+    error_function,
+  ) {
+    var initialCount = promise_function_stack.length || 0;
+    while (!us.isEmpty(promise_function_stack)) {
+      var promise_runner = promise_function_stack.shift();
+      try {
+        var resp = await promise_runner();
+        accumulator_function(resp, anchor);
+      } catch (err) {
+        if (err) {
+          error_function(err, anchor);
+        }
+        return initialCount;
+      }
+    }
+    final_function(anchor);
+    return initialCount;
+  };
+}
+bbop.extend(manager_base, registry);
+
+manager_base.prototype.fetch = function (url, payload, method, headers) {
+  var anchor = this;
+  anchor._logger.kvetch("called fetch");
+
+  this._ensure_arguments(url, payload, method, headers);
+
+  var response = new this._response_handler(this.payload());
+  response.okay(true);
+  response.message("empty");
+  response.message_type("success");
+
+  this._apply_callbacks_by_response(response);
+
+  return response;
+};
+
+manager_base.prototype.start = function (url, payload, method, headers) {
+  this._ensure_arguments(url, payload, method, headers);
+
+  var response = new this._response_handler(this.payload());
+  response.okay(true);
+  response.message("empty");
+  response.message_type("success");
+
+  this._apply_callbacks_by_response(response);
+
+  return Promise.resolve(response);
+};
+
+var manager_fetch = function (response_handler) {
+  manager_base.call(this, response_handler);
+  this._is_a = "bbop-rest-manager.fetch";
+};
+bbop.extend(manager_fetch, manager_base);
+
+manager_fetch.prototype.fetch = function (url, payload, method, headers) {
+  this._logger.kvetch("called fetch");
+  this.start(url, payload, method, headers);
+  return null;
+};
+
+manager_fetch.prototype.start = async function (url, payload, method, headers) {
+  var anchor = this;
+
+  this._ensure_arguments(url, payload, method, headers);
+
+  var requestMethod = methodWithDefault(anchor.method());
+  var requestUrl = buildUrl(anchor.resource(), anchor.payload(), requestMethod);
+  var requestInit = buildRequestInit(anchor.payload(), requestMethod, anchor.headers());
+
+  try {
+    var fetchResponse = await fetch(requestUrl, requestInit);
+    var rawText = await fetchResponse.text();
+    var response = new anchor._response_handler(rawText);
+
+    if (fetchResponse.ok && response && response.okay()) {
+      anchor.apply_callbacks("success", [response, anchor]);
+      return response;
+    }
+
+    if (!response) {
+      response = new anchor._response_handler(null);
+    }
+    response.okay(false);
+    response.message_type("error");
+    if (!rawText) {
+      response.message(`HTTP ${fetchResponse.status}`);
+    } else if (fetchResponse.ok) {
+      response.message("bad response");
+    } else {
+      response.message(`HTTP ${fetchResponse.status}`);
+    }
+    anchor.apply_callbacks("error", [response, anchor]);
+    return response;
+  } catch (error) {
+    var errorResponse = new anchor._response_handler(null);
+    errorResponse.okay(false);
+    errorResponse.message(normalizeErrorMessage(error));
+    errorResponse.message_type("error");
+    anchor.apply_callbacks("error", [errorResponse, anchor]);
+    return errorResponse;
+  }
+};
+
+var manager_node = function (response_handler) {
+  manager_fetch.call(this, response_handler);
+  this._is_a = "bbop-rest-manager.node";
+};
+bbop.extend(manager_node, manager_fetch);
+
+var manager_sync_request = function (response_handler) {
+  manager_fetch.call(this, response_handler);
+  this._is_a = "bbop-rest-manager.sync_request";
+};
+bbop.extend(manager_sync_request, manager_fetch);
+
+manager_sync_request.prototype.fetch = function (url, payload, method, headers) {
+  warnDeprecated(
+    "bbop-rest-manager.sync_request is deprecated; requests are now asynchronous and fetch() returns null. Use start() instead.",
+  );
+  this._logger.kvetch("called fetch");
+  manager_fetch.prototype.start.call(this, url, payload, method, headers);
+  return null;
+};
+
+manager_sync_request.prototype.start = function (url, payload, method, headers) {
+  warnDeprecated(
+    "bbop-rest-manager.sync_request is deprecated; requests are now asynchronous. Use start() as a promise-based API.",
+  );
+  return manager_fetch.prototype.start.call(this, url, payload, method, headers);
+};
+
+var manager_jquery = function (response_handler) {
+  manager_fetch.call(this, response_handler);
+  this._is_a = "bbop-rest-manager.jquery";
+  this._use_jsonp = false;
+  this._jsonp_callback = "json.wrf";
+};
+bbop.extend(manager_jquery, manager_fetch);
+
+manager_jquery.prototype.use_jsonp = function (use_p) {
+  if (typeof use_p !== "undefined") {
+    warnDeprecated(
+      "bbop-rest-manager.jquery JSONP support has been removed; use_jsonp() is now a no-op.",
+    );
+  }
+  return this._use_jsonp;
+};
+
+manager_jquery.prototype.jsonp_callback = function (cstring) {
+  if (typeof cstring !== "undefined") {
+    warnDeprecated(
+      "bbop-rest-manager.jquery JSONP support has been removed; jsonp_callback() is now a no-op.",
+    );
+  }
+  return this._jsonp_callback;
+};
+
+export default {
+  base: manager_base,
+  node: manager_node,
+  sync_request: manager_sync_request,
+  jquery: manager_jquery,
+};

--- a/packages/bbop-rest-manager/src/manager.js
+++ b/packages/bbop-rest-manager/src/manager.js
@@ -95,7 +95,7 @@ function normalizeErrorMessage(error) {
 }
 
 /**
- * Contructor for the REST manager.
+ * Constructor for the REST manager.
  *
  * See also: module:bbop-registry
  *

--- a/packages/bbop-rest-manager/src/manager.test.js
+++ b/packages/bbop-rest-manager/src/manager.test.js
@@ -13,9 +13,7 @@ var manager_jquery = managers.jquery;
 var response_base = bbopRestResponse.base;
 var response_json = bbopRestResponse.json;
 
-var start_port = 3344;
-var target = `http://localhost:${start_port}`;
-
+var target = null;
 var test_server = null;
 before(async function () {
   var app = express();
@@ -68,8 +66,10 @@ before(async function () {
   });
 
   await new Promise(function (resolve) {
-    test_server = app.listen(start_port, resolve);
+    test_server = app.listen(0, resolve);
   });
+  var port = test_server.address().port;
+  target = "http://localhost:" + port;
 });
 
 after(async function () {

--- a/packages/bbop-rest-manager/src/manager.test.js
+++ b/packages/bbop-rest-manager/src/manager.test.js
@@ -1,0 +1,336 @@
+import { after, before, describe, it, mock } from "node:test";
+import { assert } from "chai";
+import express from "express";
+import bodyParser from "body-parser";
+import managers from "./manager.js";
+import bbopRestResponse from "bbop-rest-response";
+
+var manager_base = managers.base;
+var manager_node = managers.node;
+var manager_sync_request = managers.sync_request;
+var manager_jquery = managers.jquery;
+
+var response_base = bbopRestResponse.base;
+var response_json = bbopRestResponse.json;
+
+var start_port = 3344;
+var target = `http://localhost:${start_port}`;
+
+var test_server = null;
+before(async function () {
+  var app = express();
+  app.use(
+    bodyParser.json({
+      type: ["application/json", "application/sparql-results+json"],
+    }),
+  );
+  app.use(bodyParser.urlencoded({ extended: true }));
+  app.get("/error", function (req, res) {
+    var q = null;
+    if (req && req.query && req.query.q) {
+      q = req.query.q;
+    }
+    res.status(500);
+    res.send({ text: "error", q: q, method: "GET" });
+  });
+  app.get("/", function (req, res) {
+    var q = null;
+    if (req && req.query && req.query.q) {
+      q = req.query.q;
+    }
+    res.send({ text: "hello world", q: q, method: "GET" });
+  });
+  app.post("/", function (req, res) {
+    var q = null;
+    if (req && req.body && req.body.q) {
+      q = req.body.q;
+    }
+    res.send({ text: "hello world", q: q, method: "POST" });
+  });
+  app.all("/headers", function (req, res) {
+    res.send({
+      head: { vars: ["rtcl"] },
+      results: {
+        bindings: [
+          {
+            rtcl: {
+              type: "uri",
+              value: "http://example.org/resource/1",
+            },
+          },
+        ],
+      },
+      accept: req.get("accept") || null,
+      method: req.method,
+      query: req.query.query || null,
+      posted_query: req.body?.query || null,
+    });
+  });
+
+  await new Promise(function (resolve) {
+    test_server = app.listen(start_port, resolve);
+  });
+});
+
+after(async function () {
+  if (test_server) {
+    await new Promise(function (resolve, reject) {
+      test_server.close(function (error) {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+});
+
+describe("bbop-rest-manager#base + bbop-rest-response#base", function () {
+  it("basic sync (watch callback)", function () {
+    var str = "";
+    var m = new manager_base(response_base);
+    m.register("success", function () {
+      str = str + "A";
+    });
+    m.resource("foo");
+
+    m.fetch();
+    assert.equal(str, "A");
+    m.fetch();
+    assert.equal(str, "AA");
+  });
+
+  it("basic sync (watch response)", function () {
+    var m = new manager_base(response_base);
+    m.resource("foo");
+
+    var r = m.fetch();
+    assert.equal(r.okay(), true);
+    assert.equal(r.message_type(), "success");
+    assert.equal(r.message(), "empty");
+  });
+
+  it("basic async (watch callback)", async function () {
+    var str = "";
+    var m = new manager_base(response_base);
+    m.register("success", function () {
+      str = str + "A";
+    });
+    m.resource("foo");
+
+    await m.start();
+    assert.equal(str, "A");
+    await m.start();
+    assert.equal(str, "AA");
+  });
+
+  it("basic async (watch promise)", async function () {
+    var m = new manager_base(response_base);
+    m.resource("foo");
+
+    var r = await m.start();
+    assert.equal(r.okay(), true);
+    assert.equal(r.message_type(), "success");
+    assert.equal(r.message(), "empty");
+  });
+});
+
+describe("bbop-rest-manager#base + bbop-rest-response#json", function () {
+  it("mostly just testing the response here, tested manager above", async function () {
+    var total = 0;
+    var m = new manager_base(response_json);
+    m.register("success", function (resp) {
+      total += resp.raw().foo.bar;
+    });
+
+    await m.start("foo", { foo: { bar: 1 } });
+    assert.equal(total, 1);
+    await m.start();
+    assert.equal(total, 2);
+    await m.start("bar", { foo: { bar: 2 } });
+    assert.equal(total, 4);
+  });
+});
+
+describe("bbop-rest-manager#node + bbop-rest-response#json", function () {
+  it("basic successful async (callbacks)", async function () {
+    var path = "/";
+    var seen = false;
+
+    var m = new manager_node(response_json);
+    m.register("success", function (resp) {
+      seen = true;
+      assert.equal(resp.raw().text, "hello world");
+    });
+    m.register("error", function () {
+      assert.fail("error callback is not expected");
+    });
+
+    await m.start(target + path);
+    assert.equal(seen, true);
+  });
+
+  it("basic successful async (promise)", async function () {
+    var m = new manager_node(response_json);
+    var resp = await m.start(target + "/");
+    assert.equal(resp.raw().text, "hello world");
+  });
+
+  it("basic error async (callback)", async function () {
+    var seen = false;
+    var m = new manager_node(response_json);
+    m.register("error", function () {
+      seen = true;
+    });
+
+    await m.start(target + "/error");
+    assert.equal(seen, true);
+  });
+
+  it("basic error async (promise)", async function () {
+    var m = new manager_node(response_json);
+    var resp = await m.start(target + "/error");
+    assert.equal(resp.okay(), false);
+  });
+
+  it("see if we can actually supply payload arguments (GET)", async function () {
+    var m = new manager_node(response_json);
+    var resp = await m.start(target + "/", { q: "foo" }, "GET");
+    assert.equal(resp.raw().q, "foo");
+  });
+
+  it("see if we can actually supply payload arguments (POST)", async function () {
+    var m = new manager_node(response_json);
+    var resp = await m.start(target + "/", { q: "foo" }, "POST");
+    assert.equal(resp.raw().q, "foo");
+  });
+});
+
+describe("bbop-rest-manager#sync_request compatibility", function () {
+  it("fetch warns and returns null while starting async work", async function () {
+    var warnings = [];
+    var warn = mock.method(console, "warn", function (message) {
+      warnings.push(message);
+    });
+
+    try {
+      var m = new manager_sync_request(response_json);
+      var seen = false;
+      var completion = new Promise(function (resolve) {
+        m.register("success", function (resp) {
+          seen = true;
+          assert.equal(resp.raw().text, "hello world");
+          resolve();
+        });
+      });
+
+      var result = m.fetch(target + "/");
+      assert.equal(result, null);
+      await completion;
+      assert.equal(seen, true);
+      assert.equal(warnings.length, 1);
+      assert.match(warnings[0], /deprecated/);
+    } finally {
+      warn.mock.restore();
+    }
+  });
+
+  it("start warns and behaves asynchronously", async function () {
+    var warnings = [];
+    var warn = mock.method(console, "warn", function (message) {
+      warnings.push(message);
+    });
+
+    try {
+      var m = new manager_sync_request(response_json);
+      var resp = await m.start(target + "/", { q: "foo" }, "POST");
+      assert.equal(resp.raw().q, "foo");
+      assert.equal(warnings.length, 1);
+      assert.match(warnings[0], /deprecated/);
+    } finally {
+      warn.mock.restore();
+    }
+  });
+});
+
+describe("bbop-rest-manager#jquery compatibility", function () {
+  it("uses fetch-backed transport for callback flow", async function () {
+    var seen = false;
+    var m = new manager_jquery(response_json);
+    m.register("success", function (resp) {
+      seen = true;
+      assert.equal(resp.raw().text, "hello world");
+    });
+
+    await m.start(target + "/");
+    assert.equal(seen, true);
+  });
+
+  it("supports GET and POST payloads", async function () {
+    var m = new manager_jquery(response_json);
+    var getResp = await m.start(target + "/", { q: "foo" }, "GET");
+    assert.equal(getResp.raw().q, "foo");
+
+    var postResp = await m.start(target + "/", { q: "bar" }, "POST");
+    assert.equal(postResp.raw().q, "bar");
+  });
+
+  it("jsonp methods warn and are otherwise no-ops", function () {
+    var warnings = [];
+    var warn = mock.method(console, "warn", function (message) {
+      warnings.push(message);
+    });
+
+    try {
+      var m = new manager_jquery(response_json);
+      assert.equal(m.use_jsonp(), false);
+      assert.equal(m.jsonp_callback(), "json.wrf");
+      assert.equal(m.use_jsonp(true), false);
+      assert.equal(m.jsonp_callback("callback"), "json.wrf");
+      assert.equal(warnings.length, 2);
+      assert.match(warnings[0], /JSONP support has been removed/);
+      assert.match(warnings[1], /JSONP support has been removed/);
+    } finally {
+      warn.mock.restore();
+    }
+  });
+});
+
+describe("header forwarding tests", function () {
+  it("node GET forwards headers", async function () {
+    var m = new manager_node(response_json);
+    var resp = await m.start(target + "/headers?query=test-query", null, null, [
+      ["accept", "application/sparql-results+json"],
+    ]);
+    assert.isDefined(resp.raw().head);
+    assert.isDefined(resp.raw().results);
+    assert.equal(resp.raw().accept, "application/sparql-results+json");
+    assert.equal(resp.raw().method, "GET");
+    assert.equal(resp.raw().query, "test-query");
+  });
+
+  it("node POST forwards headers", async function () {
+    var m = new manager_node(response_json);
+    var resp = await m.start(target + "/headers", { query: "test-query" }, "POST", [
+      ["accept", "application/sparql-results+json"],
+    ]);
+    assert.isDefined(resp.raw().head);
+    assert.isDefined(resp.raw().results);
+    assert.equal(resp.raw().accept, "application/sparql-results+json");
+    assert.equal(resp.raw().method, "POST");
+    assert.equal(resp.raw().posted_query, "test-query");
+  });
+
+  it("jquery alias GET forwards headers", async function () {
+    var m = new manager_jquery(response_json);
+    var resp = await m.start(target + "/headers?query=test-query", null, null, [
+      ["accept", "application/sparql-results+json"],
+    ]);
+    assert.isDefined(resp.raw().head);
+    assert.isDefined(resp.raw().results);
+    assert.equal(resp.raw().accept, "application/sparql-results+json");
+    assert.equal(resp.raw().method, "GET");
+    assert.equal(resp.raw().query, "test-query");
+  });
+});


### PR DESCRIPTION
Fixes #11 

These changes bring the source for `bbop-rest-manager` in as a new workspace package. The import of this package includes some modernizations and simplifications that do introduce breaking changes. I do not believe that known clients of this package will be tremendously effected.

- `bbop-rest-manager` now uses a single [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)-based asynchronous transport in all environments; the old split between Node HTTP, jQuery AJAX, and `sync-request` is gone.
- `start` now returns a standard native [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) instead of a `Q` promise. `Q`-specific methods like `fail` and `done` are no longer available. Use standard methods `catch` and `finally` instead.
- `sync_request` is now a deprecated compatibility alias only. **It no longer performs synchronous requests**. This is in accordance with the [underlying library's](https://www.npmjs.com/package/sync-request) own advice that synchronous requests probably aren't a good idea.
- `fetch` remains fire-and-forget and returns `null`; callers should use `start` for promise-based flow.
- **JSONP support has been removed**. `use_jsonp` and `jsonp_callback` remain only as deprecated no-ops for compatibility.