### PR TITLE
Add `bbop-manager-sparql` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3141,6 +3141,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-arraybuffer": {
@@ -3372,6 +3373,7 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3836,6 +3838,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -4995,12 +4998,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5746,21 +5743,11 @@
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -6721,6 +6708,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
       "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -7558,6 +7546,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -8153,15 +8142,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -9486,12 +9466,6 @@
         "readable-stream": "^3.0.0"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ssri": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
@@ -10240,6 +10214,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -10334,50 +10309,6 @@
       },
       "engines": {
         "node": ">= 14.6"
-      }
-    },
-    "node_modules/yamljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
-      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "glob": "^7.0.5"
-      },
-      "bin": {
-        "json2yaml": "bin/json2yaml",
-        "yaml2json": "bin/yaml2json"
-      }
-    },
-    "node_modules/yamljs/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/yamljs/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/yargs": {
@@ -10545,13 +10476,28 @@
         "bbop-registry": "^0.0.3",
         "mustache": "^4.2.0",
         "underscore": "^1.13.8",
-        "yamljs": "^0.3.0"
+        "yaml": "^2.8.4"
       },
       "devDependencies": {
         "chai": "^6.2.2"
       },
       "engines": {
         "node": ">=22 <25"
+      }
+    },
+    "packages/bbop-manager-sparql/node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "packages/bbop-registry": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3141,7 +3141,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-arraybuffer": {
@@ -3209,6 +3208,10 @@
     },
     "node_modules/bbop-manager-minerva": {
       "resolved": "packages/bbop-manager-minerva",
+      "link": true
+    },
+    "node_modules/bbop-manager-sparql": {
+      "resolved": "packages/bbop-manager-sparql",
       "link": true
     },
     "node_modules/bbop-registry": {
@@ -3369,7 +3372,6 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3834,7 +3836,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -4994,6 +4995,12 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5739,11 +5746,21 @@
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -6704,7 +6721,6 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
       "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6907,6 +6923,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/mute-stream": {
       "version": "2.0.0",
@@ -7533,7 +7558,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -8129,6 +8153,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -9453,6 +9486,12 @@
         "readable-stream": "^3.0.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ssri": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
@@ -10201,7 +10240,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -10296,6 +10334,50 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      },
+      "bin": {
+        "json2yaml": "bin/json2yaml",
+        "yaml2json": "bin/yaml2json"
+      }
+    },
+    "node_modules/yamljs/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/yamljs/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/yargs": {
@@ -10442,13 +10524,28 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "bbop-core": "^0.0.6",
-        "bbop-graph-noctua": "^0.0.35",
         "bbop-registry": "^0.0.3",
         "bbop-response-barista": "^0.0.11",
-        "bbop-rest-manager": "^0.0.17",
         "class-expression": "^0.0.13",
         "minerva-requests": "^0.0.18",
         "underscore": "^1.13.8"
+      },
+      "devDependencies": {
+        "chai": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=22 <25"
+      }
+    },
+    "packages/bbop-manager-sparql": {
+      "version": "0.0.7",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bbop-core": "^0.0.6",
+        "bbop-registry": "^0.0.3",
+        "mustache": "^4.2.0",
+        "underscore": "^1.13.8",
+        "yamljs": "^0.3.0"
       },
       "devDependencies": {
         "chai": "^6.2.2"

--- a/packages/bbop-manager-minerva/README.md
+++ b/packages/bbop-manager-minerva/README.md
@@ -14,4 +14,3 @@ NOTE: The legacy tests depended on a running noctua-dev server. In this monorepo
 [GitHub](https://github.com/berkeleybop/bbop-js-monorepo/packages/bbop-manager-minerva)
 
 [NPM](https://www.npmjs.com/package/bbop-manager-minerva)
-

--- a/packages/bbop-manager-sparql/README.md
+++ b/packages/bbop-manager-sparql/README.md
@@ -1,0 +1,46 @@
+# bbop-manager-sparql
+
+## Overview
+
+Manager for handling communication and callbacks with a SPARQL
+endpoint; also allows for use of templates.
+
+### Availability
+
+[GitHub](https://github.com/berkeleybop/bbop-js-monorepo/packages/bbop-manager-sparql)
+
+[NPM](https://www.npmjs.com/package/bbop-manager-sparql)
+
+## Details
+
+### Contributors:
+
+Seth Carbon
+Hirokazu Chiba
+
+### Lead Contact:
+
+Seth Carbon
+
+### Problem:
+
+In our survey, most abstracted JavaScript communications libraries either target a specific platform (e.g. Node.js or jQuery) or a specific framework (e.g Vue.js). The purpose of this project is to create a simple and flexible set of JavaScript communication libraries for cross-platform and cross-framework use, specifically targeted at interacting with SPARQL endpoints: bbop-manager-sparql.
+
+### Significance
+
+Without the creation of low-level common infrastructure, developers are left to recreate the wheel, wasting unnecessary bandwidth, and possibly creating incompatible solutions that may cause more issues down the road.
+
+### Approach
+
+The JavaScript library set that we will base our work on is one already in use by applications such as AmiGO and various Noctua clients, both in browsers and on the server; the BBOP libraries ( bbop-rest-manager and berkeleybop/bbop-rest-response ) are a client/server safe abstraction that has many implementation engines for both sync and async communication, across jQuery (browser), Node.js, and Rhino. In order to support the use cases we have for these libraries (automatic GET/POST switching to help endpoint caching, SPARQL templating, etc.) we first needed make adjustments and improve these core libraries before moving on to library creation. These upstream changes, bugfixes, and test coverage ended up taking the bulk of the effort; however, with these new pieces in place, progress on bbop-manager-sparql proceeded quickly. The templating use case was easily covered, but raised questions about the best approach to take in this space, where there is no apparent leading standard.
+
+### Next steps
+
+Moving forward, the library will develop along with the use cases of the userbase; the resolution SPARQL template handling in a standard way is already under discussion, exploring both supporting a TBD standard or multiple contenders, including the custom one already in use in the library.
+
+### Context:
+
+- BH17-specific workspace: https://github.com/dbcls/bh17/wiki/JavaScript-SPARQL-Libraries-(BBOP)
+- Code repository and issue tracker: https://github.com/berkeleybop/bbop-js-monorepo/packages/bbop-manager-sparql
+- Package repository: https://www.npmjs.com/package/bbop-manager-sparql
+- License: BSD 3-clause

--- a/packages/bbop-manager-sparql/README.md
+++ b/packages/bbop-manager-sparql/README.md
@@ -36,7 +36,7 @@ The JavaScript library set that we will base our work on is one already in use b
 
 ### Next steps
 
-Moving forward, the library will develop along with the use cases of the userbase; the resolution SPARQL template handling in a standard way is already under discussion, exploring both supporting a TBD standard or multiple contenders, including the custom one already in use in the library.
+Moving forward, the library will develop along with the use cases of the userbase; resolving SPARQL template handling in a standard way is already under discussion, exploring both supporting a TBD standard or multiple contenders, including the custom one already in use in the library.
 
 ### Context:
 

--- a/packages/bbop-manager-sparql/package.json
+++ b/packages/bbop-manager-sparql/package.json
@@ -42,7 +42,7 @@
     "bbop-registry": "^0.0.3",
     "mustache": "^4.2.0",
     "underscore": "^1.13.8",
-    "yamljs": "^0.3.0"
+    "yaml": "^2.8.4"
   },
   "devDependencies": {
     "chai": "^6.2.2"

--- a/packages/bbop-manager-sparql/package.json
+++ b/packages/bbop-manager-sparql/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "bbop-manager-sparql",
+  "version": "0.0.7",
+  "description": "Manager for handling communication and callbacks with a SPARQL endpoint; also allows for use of templates.",
+  "keywords": [
+    "Berkeley BOP",
+    "RDF",
+    "SPARQL",
+    "bbop",
+    "client",
+    "node",
+    "npm",
+    "server"
+  ],
+  "homepage": "https://berkeleybop.org/",
+  "bugs": {
+    "url": "https://github.com/berkeleybop/bbop-js-monorepo/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "SJC <sjcarbon@lbl.gov>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berkeleybop/bbop-js-monorepo.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/manager.mjs",
+      "require": "./dist/manager.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown --format esm --format cjs src/manager.js",
+    "prepack": "npm run build",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "bbop-core": "^0.0.6",
+    "bbop-registry": "^0.0.3",
+    "mustache": "^4.2.0",
+    "underscore": "^1.13.8",
+    "yamljs": "^0.3.0"
+  },
+  "devDependencies": {
+    "chai": "^6.2.2"
+  },
+  "engines": {
+    "node": ">=22 <25"
+  }
+}

--- a/packages/bbop-manager-sparql/src/fixtures/template-01.yaml
+++ b/packages/bbop-manager-sparql/src/fixtures/template-01.yaml
@@ -1,0 +1,19 @@
+title: "Get PubMed info for a PMID."
+description: "Get title, author, journal, and date by PMID."
+endpoint: "https://query.wikidata.org/sparql"
+variables:
+  - name: pmid
+    comment: The intended PMID, just the local part.
+query: >
+  PREFIX wd: <http://www.wikidata.org/entity/>
+  PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+
+  SELECT ?rtcl ?title ?author ?journal ?date
+  WHERE
+  {
+    ?rtcl wdt:P698 "{{ pmid }}".
+    OPTIONAL { ?rtcl wdt:P1476 ?title. }
+    OPTIONAL { ?rtcl wdt:P2093 ?author. }
+    OPTIONAL { ?rtcl wdt:P1433 ?journal. }
+    OPTIONAL { ?rtcl wdt:P577 ?date. }
+  }

--- a/packages/bbop-manager-sparql/src/fixtures/template-01.yaml
+++ b/packages/bbop-manager-sparql/src/fixtures/template-01.yaml
@@ -4,7 +4,7 @@ endpoint: "https://query.wikidata.org/sparql"
 variables:
   - name: pmid
     comment: The intended PMID, just the local part.
-query: >
+query: |
   PREFIX wd: <http://www.wikidata.org/entity/>
   PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 

--- a/packages/bbop-manager-sparql/src/fixtures/template-02.yaml
+++ b/packages/bbop-manager-sparql/src/fixtures/template-02.yaml
@@ -4,7 +4,7 @@ endpoint: "https://query.wikidata.org/sparql"
 variables:
   - name: pmid
     comment: The intended PMID, just the local part.
-query: >
+query: |
   SELECT ?rtcl ?title ?author ?journal ?date
   WHERE
   {

--- a/packages/bbop-manager-sparql/src/fixtures/template-02.yaml
+++ b/packages/bbop-manager-sparql/src/fixtures/template-02.yaml
@@ -1,0 +1,16 @@
+title: "Get PubMed info for a PMID. (sans)"
+description: "Get title, author, journal, and date by PMID. This query does not include prefixes; you will need to include prefixes in your software parsing."
+endpoint: "https://query.wikidata.org/sparql"
+variables:
+  - name: pmid
+    comment: The intended PMID, just the local part.
+query: >
+  SELECT ?rtcl ?title ?author ?journal ?date
+  WHERE
+  {
+    ?rtcl wdt:P698 "{{ pmid }}".
+    OPTIONAL { ?rtcl wdt:P1476 ?title. }
+    OPTIONAL { ?rtcl wdt:P2093 ?author. }
+    OPTIONAL { ?rtcl wdt:P1433 ?journal. }
+    OPTIONAL { ?rtcl wdt:P577 ?date. }
+  }

--- a/packages/bbop-manager-sparql/src/fixtures/template-03.yaml
+++ b/packages/bbop-manager-sparql/src/fixtures/template-03.yaml
@@ -1,0 +1,21 @@
+title: "Get PubMed info for a PMID. (exp)"
+description: "Get title, author, journal, and date by PMID. The prefixes are stored in an optional field in this file."
+endpoint: "https://query.wikidata.org/sparql"
+prefixes:
+  - prefix: wd
+    expansion: <http://www.wikidata.org/entity/>
+  - prefix: wdt
+    expansion: <http://www.wikidata.org/prop/direct/>
+variables:
+  - name: pmid
+    comment: The intended PMID, just the local part.
+query: >
+  SELECT ?rtcl ?title ?author ?journal ?date
+  WHERE
+  {
+    ?rtcl wdt:P698 "{{ pmid }}".
+    OPTIONAL { ?rtcl wdt:P1476 ?title. }
+    OPTIONAL { ?rtcl wdt:P2093 ?author. }
+    OPTIONAL { ?rtcl wdt:P1433 ?journal. }
+    OPTIONAL { ?rtcl wdt:P577 ?date. }
+  }

--- a/packages/bbop-manager-sparql/src/fixtures/template-03.yaml
+++ b/packages/bbop-manager-sparql/src/fixtures/template-03.yaml
@@ -9,7 +9,7 @@ prefixes:
 variables:
   - name: pmid
     comment: The intended PMID, just the local part.
-query: >
+query: |
   SELECT ?rtcl ?title ?author ?journal ?date
   WHERE
   {

--- a/packages/bbop-manager-sparql/src/fixtures/template-04.yaml
+++ b/packages/bbop-manager-sparql/src/fixtures/template-04.yaml
@@ -9,7 +9,7 @@ prefixes:
 variables:
   - name: pmid
     comment: The intended PMID, just the local part.
-query: |+
+query: |
   SELECT ?rtcl ?title ?author ?journal ?date
   WHERE
   {

--- a/packages/bbop-manager-sparql/src/fixtures/template-04.yaml
+++ b/packages/bbop-manager-sparql/src/fixtures/template-04.yaml
@@ -1,0 +1,21 @@
+title: "Get PubMed info for a PMID. (exp)"
+description: "Get title, author, journal, and date by PMID. The prefixes are stored in an optional field in this file."
+endpoint: "https://query.wikidata.org/sparql"
+prefixes:
+  - prefix: wd
+    expansion: <http://www.wikidata.org/entity/>
+  - prefix: wdt
+    expansion: <http://www.wikidata.org/prop/direct/>
+variables:
+  - name: pmid
+    comment: The intended PMID, just the local part.
+query: |+
+  SELECT ?rtcl ?title ?author ?journal ?date
+  WHERE
+  {
+    ?rtcl wdt:P698 "{{ pmid }}".
+    OPTIONAL { ?rtcl wdt:P1476 ?title. }
+    OPTIONAL { ?rtcl wdt:P2093 ?author. }
+    OPTIONAL { ?rtcl wdt:P1433 ?journal. }
+    OPTIONAL { ?rtcl wdt:P577 ?date. }
+  }

--- a/packages/bbop-manager-sparql/src/fixtures/template-05.yaml
+++ b/packages/bbop-manager-sparql/src/fixtures/template-05.yaml
@@ -7,7 +7,7 @@ endpoint: "https://rdf.geneontology.org/sparql"
 variables:
   model_id:
     comment: The intended GO model.
-query: |+
+query: |
   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
   PREFIX gomodel: <http://model.geneontology.org/#>

--- a/packages/bbop-manager-sparql/src/fixtures/template-05.yaml
+++ b/packages/bbop-manager-sparql/src/fixtures/template-05.yaml
@@ -1,0 +1,19 @@
+title: "Trival query (for a model)."
+handle: "trivial05"
+description: "A completely trivial query, with a higher limit and for a model."
+tags:
+  - "TODO"
+endpoint: "https://rdf.geneontology.org/sparql"
+variables:
+  model_id:
+    comment: The intended GO model.
+query: |+
+  PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+  PREFIX gomodel: <http://model.geneontology.org/#>
+  SELECT * WHERE {
+    GRAPH { {{ model_id }}
+      ?sub ?pred ?obj .
+    }
+  }
+  LIMIT 20

--- a/packages/bbop-manager-sparql/src/fixtures/template-05.yaml
+++ b/packages/bbop-manager-sparql/src/fixtures/template-05.yaml
@@ -1,4 +1,4 @@
-title: "Trival query (for a model)."
+title: "Trivial query (for a model)."
 handle: "trivial05"
 description: "A completely trivial query, with a higher limit and for a model."
 tags:

--- a/packages/bbop-manager-sparql/src/manager.js
+++ b/packages/bbop-manager-sparql/src/manager.js
@@ -54,7 +54,7 @@ var manager = function (endpoint, prefixes, response_handler, engine, mode) {
       } else if (anchor._mode === "async") {
         ret = anchor._engine.start(resource, payload);
       } else {
-        throw new Error('"mode" not set in new bbop-manager-minerva');
+        throw new Error('"mode" not set in new bbop-manager-sparql');
       }
       return ret;
     };

--- a/packages/bbop-manager-sparql/src/manager.js
+++ b/packages/bbop-manager-sparql/src/manager.js
@@ -1,0 +1,255 @@
+/**
+ * Manager for handling communication and callbacks with a SPARQL
+ * endpoint; also allows for use of templates.
+ *
+ * @modules bbop-manager-sparql
+ */
+
+import bbop from "bbop-core";
+import registry from "bbop-registry";
+
+import us from "underscore";
+import mustache from "mustache";
+import yaml from "yamljs";
+
+/**
+ * A manager for handling the AJAX and registry. Initial take from
+ * {module:bbop-rest-manager}.
+ *
+ * @constructor
+ * @param {String} endpoint - string for the target endpoint URL
+ * @param {Array} prefixes - a list of array pairs (e.g. [['wdt', '<http://www.wikidata.org/prop/direct/>'], ...]) that will be added to all queries, whether a template is used or not.
+ * @param {Object} response_handler - the response handler class to use for each call
+ * @param {Object} engine - Remote resource manager client to use (must be an instantiated {module:bbop-rest-manager} engine)
+ * @param {String} *optional* mode - mode control for the engine (optional)
+ * @returns {manager} a classic manager
+ */
+var manager = function (endpoint, prefixes, response_handler, engine, mode) {
+  registry.call(this, ["success", "error"]);
+  this._is_a = "bbop-manager-sparql";
+  var anchor = this;
+
+  // Endpoint.
+  anchor._endpoint = endpoint;
+
+  // New prefixes.
+  anchor._prefixes = [];
+  if (prefixes && us.isArray(prefixes)) {
+    anchor._prefixes = prefixes;
+  }
+
+  // Are we using this for the manager, or just ths template engine?
+  anchor._manager_p = true;
+  if (!engine || !response_handler) {
+    anchor._manager_p = false;
+  } else {
+    anchor._engine = engine;
+    anchor._mode = mode;
+    anchor._runner = function (resource, payload) {
+      // console.log('resource', resource);
+      // console.log('payload', payload);
+      var ret = null;
+      if (anchor._mode === "sync") {
+        ret = anchor._engine.fetch(resource, payload);
+      } else if (anchor._mode === "async") {
+        ret = anchor._engine.start(resource, payload);
+      } else {
+        throw new Error('"mode" not set in new bbop-manager-minerva');
+      }
+      return ret;
+    };
+  }
+
+  // How to deal with failure.
+  function _on_fail(resp, man) {
+    var retval = null;
+
+    // See if we got any traction.
+    if (!resp || !resp.message_type() || !resp.message()) {
+      // Something dark has happened, try to put something
+      // together.
+      // console.log('bad resp!?: ', resp);
+      var resp_seed = {
+        message_type: "error",
+        message: "deep manager error",
+      };
+      resp = new response_handler(resp_seed);
+      retval = resp;
+    }
+    anchor.apply_callbacks("error", [resp, anchor]);
+
+    return retval;
+  }
+  if (anchor._manager_p) {
+    anchor._engine.register("error", _on_fail);
+  }
+
+  // When we have nominal success, we still need to do some kind of
+  // dispatch to the proper functionality.
+  function _on_nominal_success(resp, man) {
+    var retval = resp;
+    anchor.apply_callbacks("success", [resp, anchor]);
+
+    return retval;
+  }
+  if (anchor._manager_p) {
+    anchor._engine.register("success", _on_nominal_success);
+  }
+};
+bbop.extend(manager, registry);
+
+/**
+ * Get/set the endpoint.
+ *
+ * @param {String} endpoint - a string for the endpoint URL.
+ * @returns {String} current value
+ */
+manager.prototype.endpoint = function (endpoint) {
+  var anchor = this;
+
+  if (endpoint && us.isString(endpoint)) {
+    anchor._endpoint = endpoint;
+  }
+
+  return anchor._endpoint;
+};
+
+/**
+ * Get/set the prefixes.
+ *
+ * @param {Array} prefixes - a list of array pairs (e.g. [['wdt', '<http://www.wikidata.org/prop/direct/>'], ...]) that will be added to all queries, whether a template is used or not.
+ * @returns {Array} current value(s), as array of pairs.
+ */
+manager.prototype.prefixes = function (prefixes) {
+  var anchor = this;
+
+  if (prefixes && us.isArray(prefixes)) {
+    anchor._prefixes = prefixes;
+  }
+
+  return anchor._prefixes;
+};
+
+/**
+ * Add a prefix.
+ *
+ * @param {String} prefix - prefix
+ * @param {String} expansion - expansion
+ * @returns {Array} current value(s), as array of pairs.
+ */
+manager.prototype.add_prefix = function (prefix, expansion) {
+  var anchor = this;
+
+  if (prefix && us.isString(prefix) && expansion && us.isString(expansion)) {
+    anchor._prefixes.push([prefix, expansion]);
+  }
+
+  return anchor._prefixes;
+};
+
+/**
+ * Attempt to query using the string. For shorter queries, try GET
+ * (some systems will cache these), for longer, fall back on POST.
+ *
+ * This is the core operator for this subclass. Any prefixes() will be
+ * appended.
+ *
+ * @param {String} string - the SPARQL query string
+ * @returns {Object} response
+ */
+manager.prototype.query = function (string) {
+  var anchor = this;
+
+  // Choke if somebody trie to
+  if (!anchor._manager_p) {
+    throw new Error("This manager was not provided any engine or response," + " so cannot query.");
+  }
+
+  // Add any prefixes in the object.
+  var prefixes = "";
+  //console.log('prefixes', anchor.prefixes());
+  us.each(anchor.prefixes(), function (prefix) {
+    prefixes += "PREFIX " + prefix[0] + ":" + prefix[1] + "\n";
+  });
+
+  var qstr = prefixes + string;
+  //console.log('query: qstr', qstr);
+  if (qstr.length > 1024) {
+    anchor._engine.method("GET");
+  } else {
+    anchor._engine.method("POST");
+  }
+
+  var pay = { query: qstr };
+  return anchor._runner(anchor.endpoint(), pay);
+};
+
+/**
+ * Attempt to query using a ??? template.
+ * Binding variables into a YAML mustache template.
+ *
+ * Any prefixes() will be appended.
+ *
+ * @param {String} template_as_string - the SPARQL query string
+ * @param {Object} bindings - variables to fill out the YAML template (mustache)
+ * @returns {Object} response
+ */
+manager.prototype.template = function (template_as_something, bindings) {
+  var anchor = this;
+
+  var obj = null;
+  if (us.isString(template_as_something)) {
+    // See if string string or YAML string.
+    try {
+      var pre_obj = yaml.parse(template_as_something);
+      if (pre_obj["query"]) {
+        obj = pre_obj;
+      } else {
+        // Not proper--maybe string string.
+        obj = { query: template_as_something };
+      }
+    } catch (e) {
+      // Not proper--maybe string string.
+      obj = { query: template_as_something };
+    }
+  } else if (
+    us.isObject(template_as_something) &&
+    !us.isFunction(template_as_something) &&
+    template_as_something["query"]
+  ) {
+    obj = template_as_something;
+  } else if (us.isObject(template_as_something) && !us.isFunction(template_as_something)) {
+    throw new Error("does not support this object format");
+  } else {
+    throw new Error("does not support this template format");
+  }
+
+  //
+  //console.log('template: obj', obj);
+  var filled_query_template = mustache.render(obj["query"], bindings);
+  //console.log('template: filled_query_template', filled_query_template);
+
+  // Add any prefixes in the "yaml".
+  var prefixes = "";
+  //console.log('prefixes', anchor.prefixes());
+  us.each(obj["prefixes"], function (prefix) {
+    prefixes += "PREFIX " + prefix["prefix"] + ":" + prefix["expansion"] + " ";
+  });
+
+  var qstr = prefixes + filled_query_template;
+  //console.log('template: qstr', qstr);
+  var ret = null;
+  if (anchor._manager_p) {
+    ret = anchor.query(qstr);
+  } else {
+    ret = qstr;
+  }
+
+  return ret;
+};
+
+///
+/// Exportable body.
+///
+
+export default manager;

--- a/packages/bbop-manager-sparql/src/manager.js
+++ b/packages/bbop-manager-sparql/src/manager.js
@@ -10,7 +10,7 @@ import registry from "bbop-registry";
 
 import us from "underscore";
 import mustache from "mustache";
-import yaml from "yamljs";
+import yaml from "yaml";
 
 /**
  * A manager for handling the AJAX and registry. Initial take from

--- a/packages/bbop-manager-sparql/src/manager.test.js
+++ b/packages/bbop-manager-sparql/src/manager.test.js
@@ -1,0 +1,232 @@
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { assert } from "chai";
+
+import manager from "./manager.js";
+
+function loadFixture(name) {
+  return readFileSync(new URL(`./fixtures/${name}`, import.meta.url), "utf8");
+}
+
+function makeResponse(seed) {
+  return {
+    message_type: function () {
+      return seed.message_type;
+    },
+    message: function () {
+      return seed.message;
+    },
+    raw: function () {
+      return seed.raw || null;
+    },
+  };
+}
+
+function makeResponseHandler() {
+  return function ResponseHandler(seed) {
+    this._seed = seed;
+    this.message_type = function () {
+      return (seed && (seed.message_type || seed["message_type"])) || null;
+    };
+    this.message = function () {
+      return (seed && seed.message) || null;
+    };
+  };
+}
+
+function makeEngine() {
+  var callbacks = {};
+  var calls = [];
+  var currentMethod = null;
+
+  return {
+    calls: calls,
+    callbacks: callbacks,
+    register: function (name, fn) {
+      callbacks[name] = fn;
+    },
+    method: function (nextMethod) {
+      if (typeof nextMethod !== "undefined") {
+        currentMethod = nextMethod;
+      }
+      return currentMethod;
+    },
+    fetch: function (resource, payload) {
+      calls.push({ kind: "fetch", resource: resource, payload: payload, method: currentMethod });
+      return payload;
+    },
+    start: function (resource, payload) {
+      calls.push({ kind: "start", resource: resource, payload: payload, method: currentMethod });
+      return Promise.resolve(payload);
+    },
+  };
+}
+
+describe("bbop-manager-sparql state", function () {
+  it("gets and sets endpoint and prefixes", function () {
+    var m = new manager("https://example.org/sparql", [["wd", "<http://x/>"]]);
+
+    assert.equal(m.endpoint(), "https://example.org/sparql");
+    m.endpoint("https://example.net/query");
+    assert.equal(m.endpoint(), "https://example.net/query");
+
+    assert.deepEqual(m.prefixes(), [["wd", "<http://x/>"]]);
+    m.add_prefix("wdt", "<http://y/>");
+    assert.deepEqual(m.prefixes(), [
+      ["wd", "<http://x/>"],
+      ["wdt", "<http://y/>"],
+    ]);
+  });
+});
+
+describe("bbop-manager-sparql query dispatch", function () {
+  it("uses POST for shorter queries and prepends configured prefixes", function () {
+    var engine = makeEngine();
+    var ResponseHandler = makeResponseHandler();
+    var m = new manager(
+      "https://example.org/sparql",
+      [["wd", "<http://www.wikidata.org/entity/>"]],
+      ResponseHandler,
+      engine,
+      "sync",
+    );
+
+    var result = m.query("SELECT * WHERE { ?s ?p ?o . }");
+
+    assert.equal(engine.calls.length, 1);
+    assert.equal(engine.calls[0].kind, "fetch");
+    assert.equal(engine.calls[0].method, "POST");
+    assert.equal(engine.calls[0].resource, "https://example.org/sparql");
+    assert.equal(
+      engine.calls[0].payload.query,
+      "PREFIX wd:<http://www.wikidata.org/entity/>\nSELECT * WHERE { ?s ?p ?o . }",
+    );
+    assert.equal(result, engine.calls[0].payload);
+  });
+
+  it("uses GET for longer queries", function () {
+    var engine = makeEngine();
+    var ResponseHandler = makeResponseHandler();
+    var m = new manager("https://example.org/sparql", [], ResponseHandler, engine, "sync");
+    var longQuery = "SELECT * WHERE { " + "?s ?p ?o . ".repeat(120) + "}";
+
+    m.query(longQuery);
+
+    assert.equal(engine.calls.length, 1);
+    assert.equal(engine.calls[0].method, "GET");
+  });
+
+  it("throws if query is attempted without a transport engine", function () {
+    var m = new manager("https://example.org/sparql", []);
+
+    assert.throws(function () {
+      m.query("SELECT * WHERE { ?s ?p ?o . }");
+    }, /cannot query/);
+  });
+});
+
+describe("bbop-manager-sparql templates", function () {
+  it("renders a plain string template with inline prefixes", function () {
+    var m = new manager();
+    var output = m.template(loadFixture("template-01.yaml"), { pmid: "999" });
+
+    assert.equal(
+      output,
+      'PREFIX wd: <http://www.wikidata.org/entity/> PREFIX wdt: <http://www.wikidata.org/prop/direct/>\nSELECT ?rtcl ?title ?author ?journal ?date WHERE {  ?rtcl wdt:P698 "999".\n  OPTIONAL { ?rtcl wdt:P1476 ?title. }\n  OPTIONAL { ?rtcl wdt:P2093 ?author. }\n  OPTIONAL { ?rtcl wdt:P1433 ?journal. }\n  OPTIONAL { ?rtcl wdt:P577 ?date. }\n}\n',
+    );
+  });
+
+  it("renders a template with manager-provided prefixes when yaml has none", function () {
+    var m = new manager(undefined, [
+      ["wd", "<http://www.wikidata.org/entity/>"],
+      ["wdt", "<http://www.wikidata.org/prop/direct/>"],
+    ]);
+    var output = m.template(loadFixture("template-02.yaml"), { pmid: "999" });
+
+    assert.equal(
+      output,
+      'SELECT ?rtcl ?title ?author ?journal ?date WHERE {  ?rtcl wdt:P698 "999".\n  OPTIONAL { ?rtcl wdt:P1476 ?title. }\n  OPTIONAL { ?rtcl wdt:P2093 ?author. }\n  OPTIONAL { ?rtcl wdt:P1433 ?journal. }\n  OPTIONAL { ?rtcl wdt:P577 ?date. }\n}\n',
+    );
+  });
+
+  it("renders object and yaml prefix templates exactly as the legacy code produces", function () {
+    var m = new manager();
+
+    assert.equal(
+      m.template(loadFixture("template-03.yaml"), { pmid: "999" }),
+      'PREFIX wd:<http://www.wikidata.org/entity/> PREFIX wdt:<http://www.wikidata.org/prop/direct/> SELECT ?rtcl ?title ?author ?journal ?date WHERE {  ?rtcl wdt:P698 "999".\n  OPTIONAL { ?rtcl wdt:P1476 ?title. }\n  OPTIONAL { ?rtcl wdt:P2093 ?author. }\n  OPTIONAL { ?rtcl wdt:P1433 ?journal. }\n  OPTIONAL { ?rtcl wdt:P577 ?date. }\n}\n',
+    );
+
+    assert.equal(
+      m.template(loadFixture("template-04.yaml"), { pmid: "999" }),
+      'PREFIX wd:<http://www.wikidata.org/entity/> PREFIX wdt:<http://www.wikidata.org/prop/direct/> SELECT ?rtcl ?title ?author ?journal ?date\nWHERE\n{\n  ?rtcl wdt:P698 "999".\n  OPTIONAL { ?rtcl wdt:P1476 ?title. }\n  OPTIONAL { ?rtcl wdt:P2093 ?author. }\n  OPTIONAL { ?rtcl wdt:P1433 ?journal. }\n  OPTIONAL { ?rtcl wdt:P577 ?date. }\n}\n',
+    );
+  });
+
+  it("renders template variables inside graph patterns", function () {
+    var m = new manager();
+    var output = m.template(loadFixture("template-05.yaml"), { model_id: "gomodel:123" });
+
+    assert.equal(
+      output,
+      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nPREFIX gomodel: <http://model.geneontology.org/#>\nSELECT * WHERE {\n  GRAPH { gomodel:123\n    ?sub ?pred ?obj .\n  }\n}\nLIMIT 20\n",
+    );
+  });
+
+  it("supports object templates and rejects unsupported object formats", function () {
+    var m = new manager();
+    var output = m.template(
+      {
+        prefixes: [{ prefix: "ex", expansion: "<http://example.org/>" }],
+        query: "SELECT * WHERE { ex:{{ id }} ?p ?o . }",
+      },
+      { id: "foo" },
+    );
+
+    assert.equal(output, "PREFIX ex:<http://example.org/> SELECT * WHERE { ex:foo ?p ?o . }");
+    assert.throws(function () {
+      m.template({ title: "no query field" }, {});
+    }, /does not support this object format/);
+  });
+});
+
+describe("bbop-manager-sparql callback wiring", function () {
+  it("forwards success and error callbacks from the engine", function () {
+    var engine = makeEngine();
+    var ResponseHandler = makeResponseHandler();
+    var m = new manager("https://example.org/sparql", [], ResponseHandler, engine, "sync");
+    var seen = [];
+
+    m.register("success", function (resp) {
+      seen.push(["success", resp.message()]);
+    });
+    m.register("error", function (resp) {
+      seen.push(["error", resp.message()]);
+    });
+
+    engine.callbacks.success(makeResponse({ message_type: "success", message: "ok" }), m);
+    engine.callbacks.error(makeResponse({ message_type: "error", message: "boom" }), m);
+
+    assert.deepEqual(seen, [
+      ["success", "ok"],
+      ["error", "boom"],
+    ]);
+  });
+
+  it("wraps missing error responses through the provided response handler", function () {
+    var engine = makeEngine();
+    var ResponseHandler = makeResponseHandler();
+    var m = new manager("https://example.org/sparql", [], ResponseHandler, engine, "sync");
+    var seen = null;
+
+    m.register("error", function (resp) {
+      seen = resp;
+    });
+
+    engine.callbacks.error(null, m);
+
+    assert.isNotNull(seen);
+    assert.equal(seen.message_type(), "error");
+    assert.equal(seen.message(), "deep manager error");
+  });
+});

--- a/packages/bbop-manager-sparql/src/manager.test.js
+++ b/packages/bbop-manager-sparql/src/manager.test.js
@@ -132,7 +132,19 @@ describe("bbop-manager-sparql templates", function () {
 
     assert.equal(
       output,
-      'PREFIX wd: <http://www.wikidata.org/entity/> PREFIX wdt: <http://www.wikidata.org/prop/direct/>\nSELECT ?rtcl ?title ?author ?journal ?date WHERE {  ?rtcl wdt:P698 "999".\n  OPTIONAL { ?rtcl wdt:P1476 ?title. }\n  OPTIONAL { ?rtcl wdt:P2093 ?author. }\n  OPTIONAL { ?rtcl wdt:P1433 ?journal. }\n  OPTIONAL { ?rtcl wdt:P577 ?date. }\n}\n',
+      `PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+
+SELECT ?rtcl ?title ?author ?journal ?date
+WHERE
+{
+  ?rtcl wdt:P698 "999".
+  OPTIONAL { ?rtcl wdt:P1476 ?title. }
+  OPTIONAL { ?rtcl wdt:P2093 ?author. }
+  OPTIONAL { ?rtcl wdt:P1433 ?journal. }
+  OPTIONAL { ?rtcl wdt:P577 ?date. }
+}
+`,
     );
   });
 
@@ -145,7 +157,16 @@ describe("bbop-manager-sparql templates", function () {
 
     assert.equal(
       output,
-      'SELECT ?rtcl ?title ?author ?journal ?date WHERE {  ?rtcl wdt:P698 "999".\n  OPTIONAL { ?rtcl wdt:P1476 ?title. }\n  OPTIONAL { ?rtcl wdt:P2093 ?author. }\n  OPTIONAL { ?rtcl wdt:P1433 ?journal. }\n  OPTIONAL { ?rtcl wdt:P577 ?date. }\n}\n',
+      `SELECT ?rtcl ?title ?author ?journal ?date
+WHERE
+{
+  ?rtcl wdt:P698 "999".
+  OPTIONAL { ?rtcl wdt:P1476 ?title. }
+  OPTIONAL { ?rtcl wdt:P2093 ?author. }
+  OPTIONAL { ?rtcl wdt:P1433 ?journal. }
+  OPTIONAL { ?rtcl wdt:P577 ?date. }
+}
+`,
     );
   });
 
@@ -154,12 +175,30 @@ describe("bbop-manager-sparql templates", function () {
 
     assert.equal(
       m.template(loadFixture("template-03.yaml"), { pmid: "999" }),
-      'PREFIX wd:<http://www.wikidata.org/entity/> PREFIX wdt:<http://www.wikidata.org/prop/direct/> SELECT ?rtcl ?title ?author ?journal ?date WHERE {  ?rtcl wdt:P698 "999".\n  OPTIONAL { ?rtcl wdt:P1476 ?title. }\n  OPTIONAL { ?rtcl wdt:P2093 ?author. }\n  OPTIONAL { ?rtcl wdt:P1433 ?journal. }\n  OPTIONAL { ?rtcl wdt:P577 ?date. }\n}\n',
+      `PREFIX wd:<http://www.wikidata.org/entity/> PREFIX wdt:<http://www.wikidata.org/prop/direct/> SELECT ?rtcl ?title ?author ?journal ?date
+WHERE
+{
+  ?rtcl wdt:P698 "999".
+  OPTIONAL { ?rtcl wdt:P1476 ?title. }
+  OPTIONAL { ?rtcl wdt:P2093 ?author. }
+  OPTIONAL { ?rtcl wdt:P1433 ?journal. }
+  OPTIONAL { ?rtcl wdt:P577 ?date. }
+}
+`,
     );
 
     assert.equal(
       m.template(loadFixture("template-04.yaml"), { pmid: "999" }),
-      'PREFIX wd:<http://www.wikidata.org/entity/> PREFIX wdt:<http://www.wikidata.org/prop/direct/> SELECT ?rtcl ?title ?author ?journal ?date\nWHERE\n{\n  ?rtcl wdt:P698 "999".\n  OPTIONAL { ?rtcl wdt:P1476 ?title. }\n  OPTIONAL { ?rtcl wdt:P2093 ?author. }\n  OPTIONAL { ?rtcl wdt:P1433 ?journal. }\n  OPTIONAL { ?rtcl wdt:P577 ?date. }\n}\n',
+      `PREFIX wd:<http://www.wikidata.org/entity/> PREFIX wdt:<http://www.wikidata.org/prop/direct/> SELECT ?rtcl ?title ?author ?journal ?date
+WHERE
+{
+  ?rtcl wdt:P698 "999".
+  OPTIONAL { ?rtcl wdt:P1476 ?title. }
+  OPTIONAL { ?rtcl wdt:P2093 ?author. }
+  OPTIONAL { ?rtcl wdt:P1433 ?journal. }
+  OPTIONAL { ?rtcl wdt:P577 ?date. }
+}
+`,
     );
   });
 
@@ -169,7 +208,16 @@ describe("bbop-manager-sparql templates", function () {
 
     assert.equal(
       output,
-      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nPREFIX gomodel: <http://model.geneontology.org/#>\nSELECT * WHERE {\n  GRAPH { gomodel:123\n    ?sub ?pred ?obj .\n  }\n}\nLIMIT 20\n",
+      `PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX gomodel: <http://model.geneontology.org/#>
+SELECT * WHERE {
+  GRAPH { gomodel:123
+    ?sub ?pred ?obj .
+  }
+}
+LIMIT 20
+`,
     );
   });
 


### PR DESCRIPTION
Fixes #15 

These changes add the source code for `bbop-manager-sparql` as a new workspace package. The actual source code remained the same, but the tests were significantly refactored to make them isolated unit tests that don't rely on live services.